### PR TITLE
v3.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biketag",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biketag",
-      "version": "3.2.6",
+      "version": "3.2.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@sanity/client": "2.25.1-feature-image-file-input-refactor.150",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biketag",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "The Javascript client API for BikeTag Games",
   "main": "./biketag.node.js",
   "browser": "./biketag.js",

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -485,13 +485,21 @@ export const getImgurFoundDescriptionFromBikeTagData = (
     includeDate ? getDateStringForImgurDescription(tag.foundTime) : ''
   }`
 
-export const getImgurFoundTitleFromBikeTagData = (tag: Tag): string =>
+export const getImgurFoundTitleFromBikeTagData = (
+  tag: Tag,
+  fromCombinedTag = false
+): string =>
   `${
     !tag.gps || (tag.gps.lat === 0 && tag.gps.long === 0)
       ? ''
       : `(${tag.gps.lat ?? 0}, ${tag.gps.long ?? 0}, ${tag.gps.alt ?? 0})`
   } 
-  ${tag.playerId?.length ? `[${tag.playerId}]` : ''} 
+  ${
+    !fromCombinedTag && // don't include the player id from a combined tag in the found tag
+    tag.playerId?.length
+      ? `[${tag.playerId}]`
+      : ''
+  } 
   ${tag.confirmedBoundary ? getConfirmedBoundarySymbol : ''}`
 
 export const getImgurMysteryImageHashFromBikeTagData = (
@@ -500,9 +508,14 @@ export const getImgurMysteryImageHashFromBikeTagData = (
 ): string => {
   return getImageHashFromText(tag.mysteryImageUrl, cache)
 }
-export const getImgurMysteryTitleFromBikeTagData = (tag: Tag): string =>
+export const getImgurMysteryTitleFromBikeTagData = (
+  tag: Tag,
+  fromCombinedTag = false
+): string =>
   `${
-    !tag.gps || (tag.gps.lat === 0 && tag.gps.long === 0)
+    (!fromCombinedTag && // don't include the gps from a combined tag in the mystery
+      !tag.gps) ||
+    (tag.gps.lat === 0 && tag.gps.long === 0)
       ? ''
       : `(${tag.gps.lat ?? 0}, ${tag.gps.long ?? 0}, ${tag.gps.alt ?? 0})`
   } 

--- a/src/imgur/helpers.ts
+++ b/src/imgur/helpers.ts
@@ -648,15 +648,16 @@ export const isValidUploadTagImagePayload = (
 
 export const getUpdateTagPayloadFromTagData = (
   payload: uploadTagImagePayload,
-  mystery = false
+  mystery = false,
+  combined = false
 ): uploadTagImagePayload => {
   return {
     imageHash: mystery
       ? getImgurMysteryImageHashFromBikeTagData(payload as Tag)
       : getImgurFoundImageHashFromBikeTagData(payload as Tag),
     title: mystery
-      ? getImgurMysteryTitleFromBikeTagData(payload as Tag)
-      : getImgurFoundTitleFromBikeTagData(payload as Tag),
+      ? getImgurMysteryTitleFromBikeTagData(payload as Tag, combined)
+      : getImgurFoundTitleFromBikeTagData(payload as Tag, combined),
     description: mystery
       ? getImgurMysteryDescriptionFromBikeTagData(payload as Tag)
       : getImgurFoundDescriptionFromBikeTagData(payload as Tag),

--- a/src/imgur/updateTag.ts
+++ b/src/imgur/updateTag.ts
@@ -14,8 +14,16 @@ export async function updateTag(
   cache?: typeof TinyCache
 ): Promise<BikeTagApiResponse<Tag>> {
   /// Construct imgur payloads for both mystery and found images separately
-  const imgurMysteryImagePayload = getUpdateTagPayloadFromTagData(payload, true)
-  const imgurFoundImagePayload = getUpdateTagPayloadFromTagData(payload)
+  const imgurMysteryImagePayload = getUpdateTagPayloadFromTagData(
+    payload,
+    true,
+    true
+  )
+  const imgurFoundImagePayload = getUpdateTagPayloadFromTagData(
+    payload,
+    false,
+    true
+  )
 
   return new Promise(async (resolve) => {
     let success = true


### PR DESCRIPTION
fix(imgur): made changes to ensure that the player id and gps end up with the right image metadata

The gps coordinates are saved to the found image of the previous tag and the player id is saved into the mystery image of the current/new tag.