### PR TITLE
fix(sanity): changes the apioptions to include `name` and `names`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biketag",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "The Javascript client API for BikeTag Games",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -39,7 +39,7 @@
   "homepage": "https://keneucker.github.io/biketag-api/",
   "scripts": {
     "dev": "npm run dev:node",
-    "dev:build": "npm run build && npm run compile && npm run dev",
+    "dev:build": "npm run build && npm run dev",
     "dev:node": "node examples/node/index.js",
     "dev:testnode": "node examples/node/test.js",
     "dev:upnode": "node examples/node/update.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -245,6 +245,13 @@ export class BikeTagClient extends EventEmitter {
       case DataTypes.player:
         options.game = options.game ? options.game : this.biketagConfig?.game
 
+        if (method === 'getPlayers') {
+          options.names =
+            options.names ?? options.name ? [options.name] : undefined
+        }
+
+        options.game = options.game ? options.game : this.biketagConfig?.game
+
         if (method === 'updatePlayer' || method === 'updatePlayers') {
           delete options.game
         }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -77,11 +77,13 @@ export type ApiOptions = RequireAtLeastOne<{
   host?: string
   queuehash?: string
   archivehash?: string
-  slugs?: string[]
   fields?: string[]
   slug?: string
-  tagnumbers?: number[]
+  slugs?: string[]
   tagnumber?: number
+  tagnumbers?: number[]
+  name?: string
+  names?: string[]
   account?: string
   concise?: boolean
   cached?: boolean

--- a/src/sanity/getPlayers.ts
+++ b/src/sanity/getPlayers.ts
@@ -23,6 +23,7 @@ export async function getPlayers(
     DataTypes[DataTypes.player],
     /// NOT PASSING IN THE GAME because we are not yet assigning players to games
     undefined, // payload.game,
+    /// We only support querying by a single name??
     payload.names?.length === 1 ? payload.names[0] : undefined,
     payload.slugs,
     undefined,


### PR DESCRIPTION
this update also includes changes to the default options for the getPlayers method to ensure that a request using name or names will result in the field names will be set