### PR TITLE
fix(aws): implements a different paradigm for queued tags to have a player hash in the filename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biketag",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biketag",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.839.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biketag",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "The Javascript client API for BikeTag Games",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/aws/getQueue.ts
+++ b/src/aws/getQueue.ts
@@ -66,8 +66,9 @@ export async function getQueue(
           new HeadObjectCommand({ Bucket: bucket, Key: key })
         )
 
+        // TODO: Make URL construction configurable for different S3-compatible services
         const meta: S3ImageMeta = {
-          url: `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${folder}/${fullTagId}.webp`,
+          url: `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${key}`,
           title: decodeMetadataValue(head.Metadata?.title || ''),
           description: decodeMetadataValue(head.Metadata?.description || ''),
         }

--- a/src/aws/getQueue.ts
+++ b/src/aws/getQueue.ts
@@ -60,8 +60,6 @@ export async function getQueue(
         )
         if (!match) continue
 
-        const fullTagId = `${match[1]}--${match[2]}--${match[3]}`
-
         const head = await client.send(
           new HeadObjectCommand({ Bucket: bucket, Key: key })
         )

--- a/src/aws/getQueue.ts
+++ b/src/aws/getQueue.ts
@@ -49,20 +49,25 @@ export async function getQueue(
 
       const metaList: S3ImageMeta[] = []
       for (const key of files) {
+        // Skip variants
+        if (/_medium\.webp$|_small\.webp$/i.test(key)) continue
+
         const match = key.match(
           new RegExp(
-            `${folder}/(.+?)--(mystery|found)\\.(webp|jpg|jpeg|png)$`,
+            `${folder}/(.+?)--(mystery|found)--([a-z0-9]+)\\.(webp|jpg|jpeg|png)$`,
             'i'
           )
         )
         if (!match) continue
+
+        const fullTagId = `${match[1]}--${match[2]}--${match[3]}`
 
         const head = await client.send(
           new HeadObjectCommand({ Bucket: bucket, Key: key })
         )
 
         const meta: S3ImageMeta = {
-          url: `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${key}`,
+          url: `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${folder}/${fullTagId}.webp`,
           title: decodeMetadataValue(head.Metadata?.title || ''),
           description: decodeMetadataValue(head.Metadata?.description || ''),
         }
@@ -76,17 +81,19 @@ export async function getQueue(
       if (handleResize) {
         for (let i = 0; i < tags.length; i++) {
           const tag = tags[i]
-          const tagId = tag.slug ?? `tag-${tag.tagnumber}`
           const types: ('mystery' | 'found')[] = []
           if (tag.mysteryImageUrl) types.push('mystery')
           if (tag.foundImageUrl) types.push('found')
 
           for (const type of types) {
-            const base = `queue/${tagId}--${type}`
+            const url =
+              type === 'mystery' ? tag.mysteryImageUrl! : tag.foundImageUrl!
+            const filename = url.split('/').pop() || ''
+            const base = filename.replace(/\.(webp|jpg|jpeg|png)$/i, '')
+
             const hasVariants =
-              files.includes(`${base}.webp`) &&
-              files.includes(`${base}--medium.webp`) &&
-              files.includes(`${base}--small.webp`)
+              files.includes(`${folder}/${base}_medium.webp`) &&
+              files.includes(`${folder}/${base}_small.webp`)
 
             if (!hasVariants) {
               const newUrl = await resizeAndSaveVariants({

--- a/src/aws/getTags.ts
+++ b/src/aws/getTags.ts
@@ -87,7 +87,8 @@ export async function getTags(
         if (!metadataTagnumber) continue
 
         // Validate filename and metadata agree on tagnumber
-        const filenameTagnumberMatch = filenameTagId.match(/-(\d+)(--.*)?$/)
+        const filenameOnly = filenameTagId.split('/').pop() ?? ''
+        const filenameTagnumberMatch = filenameOnly.match(/-tag-(\d+)/)
         const filenameTagnumber = filenameTagnumberMatch
           ? parseInt(filenameTagnumberMatch[1], 10)
           : null
@@ -98,7 +99,6 @@ export async function getTags(
           )
           continue
         }
-
         const existing = imageMap.get(metadataTagnumber) || {}
         imageMap.set(metadataTagnumber, {
           ...existing,

--- a/src/aws/helpers.ts
+++ b/src/aws/helpers.ts
@@ -173,6 +173,7 @@ const loadIndexFromImages = async (
         new HeadObjectCommand({ Bucket: bucket, Key: key })
       )
       const metadata = head.Metadata || {}
+      // TODO: Make URL construction configurable for different S3-compatible services
       const url = `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${key}`
       const metaImage = {
         url,

--- a/src/aws/helpers.ts
+++ b/src/aws/helpers.ts
@@ -329,7 +329,7 @@ export const resizeAndSaveVariants = async ({
   const match = url.match(/\/([^\/?#]+)$/)
   if (!match) throw new Error(`Could not extract filename from URL: ${url}`)
 
-  const originalFilename = match[1] // e.g. denver-tag-369--found.jpg
+  const originalFilename = match[1] // e.g. denver-tag-369--found--abc123.jpg
   const filenameBase = originalFilename.replace(/\.\w+$/, '') // strip extension
   const originalExt = originalFilename.split('.').pop()?.toLowerCase() || 'jpg'
   const baseKey = `${folder}/${filenameBase}`
@@ -358,7 +358,7 @@ export const resizeAndSaveVariants = async ({
   let resizedOriginalUploaded = false
 
   for (const [variant, url] of Object.entries(transforms)) {
-    const suffix = variant === 'original' ? '.webp' : `--${variant}.webp`
+    const suffix = variant === 'original' ? '.webp' : `_${variant}.webp`
     const key = `${baseKey}${suffix}`
 
     try {
@@ -439,7 +439,6 @@ export const resizeAndSaveVariants = async ({
     }
   }
 
-  // Return updated .webp URL using original base path
   return url.replace(/\.\w+$/, '.webp')
 }
 
@@ -633,6 +632,19 @@ export const moveImage = async (
   } catch (err: any) {
     return { success: false, error: err.message || String(err) }
   }
+}
+
+export const getHashedPlayerSuffix = async (
+  playerId: string
+): Promise<string> => {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(playerId)
+  const hashBuffer = await crypto.subtle.digest('SHA-1', data)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  return hashArray
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 6)
 }
 
 export interface S3UploadPayload {

--- a/src/aws/updateTag.ts
+++ b/src/aws/updateTag.ts
@@ -19,6 +19,7 @@ export async function updateTag(
 ): Promise<BikeTagApiResponse<Tag>> {
   /// TODO: put the payload logic into getDefaultOptions?
   payload.folder = payload.folder ?? 'main'
+
   const mysteryImagePayload = getUpdateTagPayloadFromTagData(
     payload as Tag,
     true
@@ -45,10 +46,25 @@ export async function updateTag(
       ? tagExistsResponse.data[0]
       : null
 
+  const getCanonicalFilename = (
+    key: string,
+    type: 'mystery' | 'found'
+  ): string => {
+    const match = key.match(
+      new RegExp(
+        `^(?:.+/)?(.*)--${type}(?:--[a-z0-9]+)?\\.(webp|jpg|jpeg|png)$`,
+        'i'
+      )
+    )
+    if (!match) throw new Error(`Invalid filename for canonicalization: ${key}`)
+    return `${match[1]}--${type}.webp`
+  }
+
   // Handle mystery image
   if (!existingTag?.mysteryImageUrl?.length) {
     const currentKey = getKeyFromUrl(payload.mysteryImageUrl)
-    const targetKey = `${payload.folder}/${currentKey.split('/').pop()}`
+    const canonicalFilename = getCanonicalFilename(currentKey, 'mystery')
+    const targetKey = `${payload.folder}/${canonicalFilename}`
 
     if (
       payload.mysteryImageUrl?.includes(`${payload.game}-biketag`) &&
@@ -91,7 +107,8 @@ export async function updateTag(
   // Handle found image
   if (!existingTag?.foundImageUrl?.length) {
     const currentKey = getKeyFromUrl(payload.foundImageUrl)
-    const targetKey = `${payload.folder}/${currentKey.split('/').pop()}`
+    const canonicalFilename = getCanonicalFilename(currentKey, 'found')
+    const targetKey = `${payload.folder}/${canonicalFilename}`
 
     if (
       payload.foundImageUrl?.includes(`${payload.game}-biketag`) &&

--- a/src/aws/updateTag.ts
+++ b/src/aws/updateTag.ts
@@ -56,7 +56,11 @@ export async function updateTag(
         'i'
       )
     )
-    if (!match) throw new Error(`Invalid filename for canonicalization: ${key}`)
+    if (!match)
+      throw new Error(
+        `Invalid filename pattern for canonicalization. Expected format: <base>--${type}[--<suffix>].<ext>, got: ${key}`
+      )
+
     return `${match[1]}--${type}.webp`
   }
 

--- a/src/aws/uploadTagImage.ts
+++ b/src/aws/uploadTagImage.ts
@@ -6,6 +6,7 @@ import { AvailableApis, HttpStatusCode } from '../common/enums'
 import { createTagObject } from '../common/data'
 import {
   encodeMetadataValue,
+  getHashedPlayerSuffix,
   getUploadTagImagePayloadFromTagData,
   isValidUploadTagImagePayload,
   normalizeUploadBody,
@@ -94,8 +95,12 @@ export async function uploadTagImage(
   ) => {
     const folder = p.folder ?? 'queue'
     const suffix = p.filenameSuffix ?? `--${imageType}`
+    const postfix =
+      folder === 'queue'
+        ? `--${await getHashedPlayerSuffix(p.foundPlayer)}`
+        : ''
     const extension = p.contentType?.includes('png') ? 'png' : 'jpg'
-    const key = `${folder}/${p.game}-tag-${p.tagnumber}${suffix}.${extension}`
+    const key = `${folder}/${p.game}-tag-${p.tagnumber}${suffix}${postfix}.${extension}`
     const bucket = `${p.game}-biketag`
     const region = p.region ?? 'nyc3'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,17 @@ export type { BikeTagConfiguration, BikeTagCredentials } from './client'
 
 export type { BikeTagApiResponse } from './common/types'
 
+export type {
+  Tag,
+  Game,
+  Player,
+  Ambassador,
+  Stat,
+  Setting,
+  Achievement,
+  Region,
+} from './common/schema'
+
 export {
   createGameObject,
   createTagObject,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,13 +28,14 @@ export default defineConfig({
       output: {
         exports: 'named',
         globals: {
-          'form-data': 'formData',
-          '@aws-sdk/client-s3': 'S3Client',
           imgur: 'ImgurClient',
           axios: 'axios',
           util: 'util',
           lodash: 'lodash',
           tinycache: 'TinyCache',
+          'form-data': 'formData',
+          '@aws-sdk/client-s3': 'S3Client',
+          '@aws-sdk/s3-request-presigner': 'S3RequestPresigner',
           '@sanity/client': 'SanityClient',
           'axios-cache-interceptor': 'axiosCacheInterceptor',
         },


### PR DESCRIPTION
this changes quite a bit of things across the aws adapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added export of several schema types (Tag, Game, Player, Ambassador, Stat, Setting, Achievement, Region) for easier integration.
  * Introduced a hashed player suffix for uploaded images in specific folders to support unique identification.

* **Bug Fixes**
  * Improved tag number extraction from filenames for more accurate validation.
  * Enhanced detection and skipping of image variants during processing.

* **Refactor**
  * Standardized image filename patterns and URL construction for consistency across uploads and processing.
  * Updated logic for generating and handling image variant filenames.
  * Introduced consistent naming conventions for image updates to ensure uniformity.

* **Chores**
  * Added configuration notes for URL construction to support different S3-compatible services.
  * Updated build configuration to include new global mappings for AWS SDK components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->