### PR TITLE
fix(aws, sanity): adds the missing getStats method for the aws source adapter

### DIFF
--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -252,12 +252,12 @@ const runTests = async (out = false) => {
     // await getPlayerAchievementsAsync("Sanity", bikeTagSanityInstance, out)
   }
 
-  // if (false) {
-  if (bikeTagAWSInstance) {
+  if (false) {
+  // if (bikeTagAWSInstance) {
     console.log(pretty("AWS BikeTag Client Instantiated"), bikeTagAWSInstance.config())
     // await getTag1Async("AWS", bikeTagAWSInstance, out)
     await get10TagsAsync("AWS", bikeTagAWSInstance, out)
-    await getQueueAsync("AWS", bikeTagAWSInstance, out, {reindex: true, handleResize: true})
+    await getQueueAsync("AWS", bikeTagAWSInstance, out) //, {reindex: true, handleResize: true})
     // await getGameAsync("AWS", bikeTagAWSInstance, out)
     // await getAllGamesAsync("AWS", bikeTagAWSInstance, out)
     await get10PlayersAsync("AWS", bikeTagAWSInstance, out)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biketag",
-  "version": "3.5.28",
+  "version": "3.5.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biketag",
-      "version": "3.5.28",
+      "version": "3.5.29",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.839.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biketag",
-  "version": "3.5.28",
+  "version": "3.5.29",
   "description": "The Javascript client API for BikeTag Games",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/aws/getStats.ts
+++ b/src/aws/getStats.ts
@@ -88,7 +88,7 @@ export async function getStats(
     data: success ? data : undefined,
     success,
     error,
-    source: AvailableApis[AvailableApis.imgur],
+    source: AvailableApis[AvailableApis.aws],
     status: success ? HttpStatusCode.Ok : HttpStatusCode.BadRequest,
   }
 }

--- a/src/aws/getStats.ts
+++ b/src/aws/getStats.ts
@@ -1,0 +1,94 @@
+import {
+  getGameHighestNumberTagsPerNumberDaysData,
+  getLongestTimeBetweenTags,
+  getPlayersWithHighestNumberTagsPerDayData,
+  getPlayersWithLongestDailyTagStreakData,
+  getTagLongestDailyStreakData,
+} from '../common/methods'
+import { getStatsPayload } from '../common/payloads'
+import {
+  BikeTagApiResponse,
+  GameHighestNumberTagsPerNumberDaysData,
+  gameLongestTimeBetweenTagsData,
+  PlayerHighestNumberTagsPerDayData,
+  PlayerStreakData,
+  StatsReportData,
+  StreakData,
+} from '../common/types'
+import { AvailableApis, HttpStatusCode } from '../common/enums'
+import TinyCache from 'tinycache'
+import { S3Client } from '@aws-sdk/client-s3'
+
+export async function getStats(
+  client: S3Client,
+  payload: getStatsPayload,
+  cache?: typeof TinyCache
+): Promise<BikeTagApiResponse<StatsReportData>> {
+  let error
+  let success
+  let data
+
+  const tagsResponse = await this.getTags(undefined, cache)
+  const playersResponse = await this.getPlayers(undefined, cache)
+
+  if (
+    playersResponse.status !== HttpStatusCode.Ok &&
+    tagsResponse.status !== HttpStatusCode.Ok
+  ) {
+    success = false
+    error = playersResponse.error ?? tagsResponse.error
+  } else {
+    // Player(s) with most tags in one day
+    const playersWithMostTagsInOneDayData: PlayerHighestNumberTagsPerDayData[] =
+      getPlayersWithHighestNumberTagsPerDayData(playersResponse.data)
+
+    // Player(s) with longest streak of daily tags
+    const playersWithLongestTagStreakDaysData: PlayerStreakData[] =
+      getPlayersWithLongestDailyTagStreakData(playersResponse.data)
+
+    // Game total number of players
+    const totalNumberOfPlayers: number = playersResponse.data.length
+
+    // Game total number of tags
+    const totalNumberOfTags: number = tagsResponse.data.length
+
+    // Game most tags in one day
+    const gameHighestNumberTagsPerOneDayData: GameHighestNumberTagsPerNumberDaysData =
+      getGameHighestNumberTagsPerNumberDaysData(tagsResponse.data)
+
+    // Game most tags in one week
+    const days = 7
+    const gameHighestNumberTagsPerSevenDaysData: GameHighestNumberTagsPerNumberDaysData =
+      getGameHighestNumberTagsPerNumberDaysData(tagsResponse.data, days)
+
+    // Game longest streak of daily tags
+    const gameLongestDailyTagStreakData: StreakData =
+      getTagLongestDailyStreakData(tagsResponse.data)
+
+    // Longest time between tags
+    const longestTimeBetweenTags: gameLongestTimeBetweenTagsData =
+      getLongestTimeBetweenTags(tagsResponse.data)
+
+    success = playersResponse.success && tagsResponse.success
+
+    data = {
+      playersWithMostTagsInOneDay: playersWithMostTagsInOneDayData,
+      playersWithLongestTagStreakDaysData: playersWithLongestTagStreakDaysData,
+      gameTotalNumberOfPlayers: totalNumberOfPlayers,
+      gameTotalNumberOfTags: totalNumberOfTags,
+      gameHighestNumberTagsPerOneDayData: gameHighestNumberTagsPerOneDayData,
+      gameHighestNumberTagsPerSevenDaysData:
+        gameHighestNumberTagsPerSevenDaysData,
+      gameLongestDailyTagStreakData: gameLongestDailyTagStreakData,
+      gameLongestTimeBetweenTags: longestTimeBetweenTags,
+    }
+  }
+
+  return {
+    data: success ? data : undefined,
+    success,
+    error,
+    source: AvailableApis[AvailableApis.imgur],
+    status: success ? HttpStatusCode.Ok : HttpStatusCode.BadRequest,
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1867,7 +1867,22 @@ export class BikeTagClient {
 
     if (clientMethod) {
       switch (options.source) {
-        case AvailableApis.sanity:
+        case AvailableApis.aws: {
+          clientMethod = clientMethod.bind({
+            getTags: this.getPassthroughApiMethod(
+              api.getTags,
+              client,
+              DataTypes.tag
+            ),
+            getPlayers: this.getPassthroughApiMethod(
+              api.getPlayers,
+              client,
+              DataTypes.player
+            ),
+          })
+          break
+        }
+        case AvailableApis.sanity: {
           clientMethod = clientMethod.bind({
             getGame: this.getPassthroughApiMethod(
               api.getGame,
@@ -1876,7 +1891,8 @@ export class BikeTagClient {
             ),
           })
           break
-        case AvailableApis.imgur:
+        }
+        case AvailableApis.imgur: {
           const getTags = this.getPassthroughApiMethod(
             api.getTags,
             client,
@@ -1892,6 +1908,7 @@ export class BikeTagClient {
             ),
           })
           break
+        }
       }
 
       return clientMethod(client, options).catch((e) => {

--- a/src/sanity/helpers.ts
+++ b/src/sanity/helpers.ts
@@ -292,17 +292,28 @@ export function constructGameFromSanityObject(
       if (gameData[f] && typeof gameData[f] !== 'undefined') {
         const fieldMap = gameDataCustomFields[f]
         if (fieldMap) {
-          if (gameDataArrayFields.indexOf(f) !== -1) {
+          if (gameDataArrayFields.includes(f)) {
             const customFieldProperties = fieldMap
               .replace('[]->{', '')
               .replace('}', '')
-            const arrayFieldKeys = customFieldProperties.split(',')
-            const key = arrayFieldKeys[0]
-            const value = arrayFieldKeys[1]
-            gameData[f] = gameData[f].reduce((o: any, kv: any) => {
-              o[kv[key]] = kv[value]
-              return o
-            }, [])
+            const [key, value] = customFieldProperties.split(',')
+
+            const isKeyValueArray =
+              Array.isArray(gameData[f]) &&
+              gameData[f].every(
+                (item) =>
+                  item &&
+                  typeof item === 'object' &&
+                  key in item &&
+                  value in item
+              )
+
+            if (isKeyValueArray) {
+              gameData[f] = gameData[f].reduce((o: any, kv: any) => {
+                o[kv[key]] = kv[value]
+                return o
+              }, {})
+            }
           } else {
             const customFieldNames = fieldMap.split(',')
 


### PR DESCRIPTION
resovles a bug within the getGame sanity adapter for the settings array, which is now an object instead of an array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AWS statistics reporting, providing insights such as player streaks, tag counts, and other game metrics.

* **Bug Fixes**
  * Improved data safety when processing custom fields to prevent errors from unexpected data formats.

* **Chores**
  * Updated package version to 3.5.29.
  * Disabled AWS client tests in the example code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->