### PR TITLE
fix(aws, common): changes the saving of metadata from a title & description to data

### DIFF
--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -13,6 +13,7 @@ const host = process.env.BIKETAG_API_HOST
 
 const biketagDefaultInstanceOpts = {
   game: process.env.BIKETAG_GAME ? process.env.BIKETAG_GAME : 'test',
+  verbose: true,
   host,
   cached: false,
   clientToken: process.env.BIKETAG_CLIENT_TOKEN,
@@ -21,6 +22,7 @@ const biketagDefaultInstance = host ? new BikeTagClient(biketagDefaultInstanceOp
 
 const imgurInstanceOpts = {
   game: process.env.BIKETAG_GAME ? process.env.BIKETAG_GAME : 'test',
+  verbose: true,
   host,
   imgur: {
     hash: process.env.IMGUR_HASH,
@@ -36,6 +38,7 @@ const bikeTagImgurInstance = imgurInstanceOpts.imgur && imgurInstanceOpts.imgur.
 
 const sanityInstanceOpts = {
   game: process.env.BIKETAG_GAME,
+  verbose: true,
   host,
   sanity: {
     projectId: process.env.SANITY_PROJECT_ID,
@@ -48,6 +51,7 @@ const bikeTagSanityInstance = sanityInstanceOpts.sanity && sanityInstanceOpts.sa
 
 const awsInstanceOpts = {
   game: process.env.BIKETAG_GAME,
+  verbose: true,
   host,
   aws: {
     accessKeyId: process.env.S3_ACCESS_ID,
@@ -252,15 +256,15 @@ const runTests = async (out = false) => {
     // await getPlayerAchievementsAsync("Sanity", bikeTagSanityInstance, out)
   }
 
-  if (false) {
-  // if (bikeTagAWSInstance) {
+  // if (false) {
+  if (bikeTagAWSInstance) {
     console.log(pretty("AWS BikeTag Client Instantiated"), bikeTagAWSInstance.config())
     // await getTag1Async("AWS", bikeTagAWSInstance, out)
     await get10TagsAsync("AWS", bikeTagAWSInstance, out)
-    await getQueueAsync("AWS", bikeTagAWSInstance, out) //, {reindex: true, handleResize: true})
+    await getQueueAsync("AWS", bikeTagAWSInstance, out, { reindex: true })
     // await getGameAsync("AWS", bikeTagAWSInstance, out)
     // await getAllGamesAsync("AWS", bikeTagAWSInstance, out)
-    await get10PlayersAsync("AWS", bikeTagAWSInstance, out)
+    // await get10PlayersAsync("AWS", bikeTagAWSInstance, out)
     // await get1PlayerAsync("AWS", bikeTagAWSInstance, out)
     // await get10AchievementsAsync("AWS", bikeTagAWSInstance, out)
     // await get10AmbassadorsAsync("AWS", bikeTagAWSInstance, out)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biketag",
-  "version": "3.5.29",
+  "version": "3.5.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biketag",
-      "version": "3.5.29",
+      "version": "3.5.30",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.839.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biketag",
-  "version": "3.5.29",
+  "version": "3.5.30",
   "description": "The Javascript client API for BikeTag Games",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/aws/deleteTag.ts
+++ b/src/aws/deleteTag.ts
@@ -14,19 +14,18 @@ import {
   loadIndex,
   saveIndex,
   getKeyFromUrl,
-  encodeMetadataValue,
+  getMysteryMetadata,
 } from './helpers'
 import { Tag } from '../common/schema'
-import {
-  getImgurMysteryTitleFromBikeTagData,
-  getImgurMysteryDescriptionFromBikeTagData,
-} from '../common/getters'
 
 export async function deleteTag(
   client: S3Client,
   payload: deleteTagPayload & { tag?: Tag }
 ): Promise<BikeTagApiResponse<boolean[]>> {
   payload.folder = payload.folder ?? 'queue'
+
+  const logVerbose = payload.verbose ? console.log : () => {}
+
   const { tagnumber, folder, game, region, mysteryPlayer, foundPlayer } =
     payload
   const bucket = `${game}-biketag`
@@ -37,22 +36,27 @@ export async function deleteTag(
   if (!tagnumber) {
     success = false
     errors.push('tagnumber not set')
+    logVerbose('[deleteTag] Missing tagnumber.')
   }
 
   if (folder === 'main' && tagnumber) {
+    logVerbose(`[deleteTag] Deleting tag #${tagnumber} from main folder...`)
     const prefix = getTagPrefix(folder, game, tagnumber)
     const list = await listAllS3Objects(client, {
       Bucket: bucket,
       Prefix: prefix,
     })
+    logVerbose(`[deleteTag] Found ${list.length} object(s) to delete.`)
 
     const deleteOps = list.map(async (obj) => {
       try {
         await client.send(
           new DeleteObjectCommand({ Bucket: bucket, Key: obj.Key })
         )
+        logVerbose(`[deleteTag] Deleted: ${obj.Key}`)
         return true
       } catch (err) {
+        logVerbose(`[deleteTag] Failed to delete ${obj.Key}:`, err.message)
         errors.push(err.message)
         return false
       }
@@ -63,6 +67,7 @@ export async function deleteTag(
   }
 
   if (folder === 'queue' && tagnumber) {
+    logVerbose(`[deleteTag] Deleting tag #${tagnumber} from queue folder...`)
     const keysToDelete: { Key: string }[] = []
 
     if (mysteryPlayer) {
@@ -78,6 +83,9 @@ export async function deleteTag(
         Bucket: bucket,
         Prefix: mysteryKey,
       })
+      logVerbose(
+        `[deleteTag] Found ${mysteryObjects.length} mystery objects to delete.`
+      )
       keysToDelete.push(...mysteryObjects.map((obj) => ({ Key: obj.Key! })))
     }
 
@@ -94,11 +102,15 @@ export async function deleteTag(
         Bucket: bucket,
         Prefix: foundKey,
       })
+      logVerbose(
+        `[deleteTag] Found ${foundObjects.length} found objects to delete.`
+      )
       keysToDelete.push(...foundObjects.map((obj) => ({ Key: obj.Key! })))
     }
 
     if (keysToDelete.length > 0) {
       try {
+        logVerbose(`[deleteTag] Deleting ${keysToDelete.length} object(s)...`)
         const result = await client.send(
           new DeleteObjectsCommand({
             Bucket: bucket,
@@ -108,13 +120,17 @@ export async function deleteTag(
         deleted.push(...keysToDelete.map(() => true))
 
         if (result.Errors && result.Errors.length > 0) {
-          result.Errors.forEach((err) =>
+          result.Errors.forEach((err) => {
+            logVerbose(
+              `[deleteTag] Failed to delete ${err.Key}: ${err.Message}`
+            )
             errors.push(`${err.Key}: ${err.Message}`)
-          )
+          })
         }
       } catch (err: any) {
         errors.push(err.message)
         deleted.push(false)
+        logVerbose('[deleteTag] DeleteObjectsCommand failed:', err.message)
       }
     }
   }
@@ -122,6 +138,7 @@ export async function deleteTag(
   let indexUpdateError = ''
   if (success && tagnumber) {
     try {
+      logVerbose('[deleteTag] Loading current index...')
       let index = await loadIndex(client, bucket, folder, region)
       const newIndex = index.filter((t) => t.tagnumber !== tagnumber)
 
@@ -129,22 +146,23 @@ export async function deleteTag(
         const idx = newIndex.findIndex((t) => t.tagnumber === tagnumber - 1)
 
         if (idx === -1) {
-          errors.push(`Previous tag ${tagnumber - 1} not found in index`)
+          const errMsg = `Previous tag ${tagnumber - 1} not found in index`
+          logVerbose('[deleteTag] ' + errMsg)
+          errors.push(errMsg)
           success = false
         } else {
+          logVerbose('[deleteTag] Resetting latest tag to mystery state...')
           const latestTag = { ...newIndex[idx] }
-
-          // Reset fields to mystery state
           latestTag.gps = { lat: 0, long: 0, alt: 0 }
           latestTag.foundPlayer = ''
           latestTag.foundImageUrl = ''
           latestTag.foundTime = 0
           latestTag.foundLocation = ''
 
-          // Refresh metadata on mystery image
           if (latestTag.mysteryImageUrl) {
             const mysteryKey = getKeyFromUrl(latestTag.mysteryImageUrl)
             try {
+              logVerbose('[deleteTag] Refreshing mystery metadata...')
               await client.send(
                 new CopyObjectCommand({
                   Bucket: bucket,
@@ -153,22 +171,15 @@ export async function deleteTag(
                   ACL: 'public-read',
                   MetadataDirective: 'REPLACE',
                   Metadata: {
-                    title: encodeMetadataValue(
-                      getImgurMysteryTitleFromBikeTagData(latestTag).trim()
-                    ),
-                    description: encodeMetadataValue(
-                      getImgurMysteryDescriptionFromBikeTagData(
-                        latestTag
-                      ).trim()
-                    ),
+                    data: getMysteryMetadata(latestTag),
                   },
                 })
               )
             } catch (err: any) {
               success = false
-              errors.push(
-                `Failed to refresh metadata for mystery image: ${err.message}`
-              )
+              const errMsg = `Failed to refresh metadata for mystery image: ${err.message}`
+              logVerbose('[deleteTag] ' + errMsg)
+              errors.push(errMsg)
             }
           }
 
@@ -176,9 +187,11 @@ export async function deleteTag(
         }
       }
 
+      logVerbose('[deleteTag] Saving updated index...')
       await saveIndex(client, bucket, folder, newIndex)
     } catch (indexErr: any) {
       indexUpdateError = `Index update failed: ${indexErr.message}`
+      logVerbose('[deleteTag] ' + indexUpdateError)
     }
   }
 

--- a/src/aws/getQueue.ts
+++ b/src/aws/getQueue.ts
@@ -104,7 +104,6 @@ export async function getQueue(
 
             if (!hasVariants) {
               logVerbose(
-                verbose,
                 `Resizing ${type} image for tag #${tag.tagnumber} (${base})`
               )
               const newUrl = await resizeAndSaveVariants({

--- a/src/aws/getQueue.ts
+++ b/src/aws/getQueue.ts
@@ -11,15 +11,18 @@ import {
   getGroupedImagesByTagnumber,
   getGroupedTagsByPlayer,
   decodeMetadataValue,
+  getTagMetadata,
 } from './helpers'
 
 export async function getQueue(
   client: S3Client,
   payload: getQueuePayload
 ): Promise<BikeTagApiResponse<Tag[]>> {
-  const { game, reindex, resize, cached, region } = payload
+  const { game, reindex, resize, cached, region, verbose } = payload
   const bucket = `${game}-biketag`
   const folder = 'queue'
+
+  const logVerbose = payload.verbose ? console.log : () => {}
 
   let tags: Tag[] = []
   let success = true
@@ -29,20 +32,26 @@ export async function getQueue(
   try {
     if (!reindex) {
       try {
+        logVerbose('[getQueue] Attempting to load index...')
         tags = await loadIndex(client, bucket, folder, region, cached, reindex)
-      } catch {
+        logVerbose(`[getQueue] Loaded ${tags.length} tags from index.`)
+      } catch (err) {
+        logVerbose('[getQueue] Failed to load index. Rebuilding...')
         needsRebuild = true
       }
     }
 
     if (needsRebuild) {
+      logVerbose('[getQueue] Listing all S3 objects...')
       const list = await listAllS3Objects(client, {
         Bucket: bucket,
         Prefix: `${folder}/`,
       })
       const files = list.map((obj) => obj.Key).filter(Boolean) as string[]
+      logVerbose(`[getQueue] Found ${files.length} files in ${folder}/`)
 
       const metaList: S3ImageMeta[] = []
+
       for (const key of files) {
         // Skip variants
         if (/_medium\.webp$|_small\.webp$/i.test(key)) continue
@@ -55,24 +64,28 @@ export async function getQueue(
         )
         if (!match) continue
 
+        logVerbose('[getQueue] Getting metadata for', key)
         const head = await client.send(
           new HeadObjectCommand({ Bucket: bucket, Key: key })
         )
 
-        // TODO: Make URL construction configurable for different S3-compatible services
         const meta: S3ImageMeta = {
           url: `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${key}`,
           title: decodeMetadataValue(head.Metadata?.title || ''),
           description: decodeMetadataValue(head.Metadata?.description || ''),
+          data: getTagMetadata(head.Metadata?.data),
         }
 
         metaList.push(meta)
       }
 
+      logVerbose(`[getQueue] Collected metadata for ${metaList.length} images`)
       const groupedImages = getGroupedImagesByTagnumber(metaList)
       tags = getGroupedTagsByPlayer(groupedImages, { game })
+      logVerbose(`[getQueue] Grouped into ${tags.length} tag(s)`)
 
       if (resize) {
+        logVerbose('[getQueue] Resizing missing image variants...')
         for (let i = 0; i < tags.length; i++) {
           const tag = tags[i]
           const types: ('mystery' | 'found')[] = []
@@ -90,6 +103,10 @@ export async function getQueue(
               files.includes(`${folder}/${base}_small.webp`)
 
             if (!hasVariants) {
+              logVerbose(
+                verbose,
+                `Resizing ${type} image for tag #${tag.tagnumber} (${base})`
+              )
               const newUrl = await resizeAndSaveVariants({
                 client,
                 tag,
@@ -103,11 +120,13 @@ export async function getQueue(
         }
       }
 
+      logVerbose('[getQueue] Saving index...')
       await saveIndex(client, bucket, folder, tags)
     }
   } catch (err: any) {
     success = false
     error = err.message
+    logVerbose('[getQueue] Error during getQueue:', error)
   }
 
   return {

--- a/src/aws/helpers.ts
+++ b/src/aws/helpers.ts
@@ -774,6 +774,7 @@ export const getTagMetadata = (
     foundTime: found.ft || 0,
     foundLocation: found.fl || '',
     gps: found.g || {},
+    confirmedBoundary: found.c || false,
     ...metadataOverrides,
   }
 

--- a/src/aws/helpers.ts
+++ b/src/aws/helpers.ts
@@ -13,10 +13,6 @@ import {
 import { Tag } from '../common/schema'
 import {
   getBikeTagFromS3ImageSet,
-  getImgurFoundDescriptionFromBikeTagData,
-  getImgurFoundTitleFromBikeTagData,
-  getImgurMysteryDescriptionFromBikeTagData,
-  getImgurMysteryTitleFromBikeTagData,
   getPlayerFromText,
   getTagNumbersFromText,
 } from '../common/getters'
@@ -26,7 +22,11 @@ import TinyCache from 'tinycache'
 import { getApiUrl } from '../biketag/helpers'
 import { CommonPayloadData } from '../common/types'
 import { getImageExtension } from '../common/methods'
-import { isFoundImage, isMysteryImage } from '../imgur/helpers'
+import {
+  isFoundImage as isImugrFoundImage,
+  isMysteryImage as isImgurMysteryImage,
+} from '../imgur/helpers'
+import { createTagObject } from '../common/data'
 
 const indexCache = new TinyCache()
 /** Returns the S3 key prefix for a given tag */
@@ -219,6 +219,7 @@ const loadIndexFromImages = async (
         url,
         title: decodeMetadataValue(metadata.title),
         description: decodeMetadataValue(metadata.description),
+        data: getTagMetadata(metadata.data),
       }
 
       const entry = imagesByTag[slug] || {}
@@ -369,17 +370,21 @@ export const resizeAndSaveVariants = async ({
           let Metadata
 
           if (variantIsOriginal) {
-            const title =
-              imageType === 'mystery'
-                ? getImgurMysteryTitleFromBikeTagData(tag)
-                : getImgurFoundTitleFromBikeTagData(tag)
-            const description =
-              imageType === 'mystery'
-                ? getImgurMysteryDescriptionFromBikeTagData(tag)
-                : getImgurFoundDescriptionFromBikeTagData(tag)
+            // const title =
+            //   imageType === 'mystery'
+            //     ? getImgurMysteryTitleFromBikeTagData(tag)
+            //     : getImgurFoundTitleFromBikeTagData(tag)
+            // const description =
+            //   imageType === 'mystery'
+            //     ? getImgurMysteryDescriptionFromBikeTagData(tag)
+            //     : getImgurFoundDescriptionFromBikeTagData(tag)
             Metadata = {
-              title: encodeMetadataValue(title.trim()),
-              description: encodeMetadataValue(description.trim()),
+              // title: encodeMetadataValue(title.trim()),
+              // description: encodeMetadataValue(description.trim()),
+              data:
+                imageType === 'mystery'
+                  ? getMysteryMetadata(tag)
+                  : getFoundMetadata(tag),
             }
           }
 
@@ -553,14 +558,26 @@ export const getGroupedTagsByPlayer = (
 
   // Group player images from the current and previous round
   for (const image of groupedImages[highestTagnumber] ?? []) {
-    const player = getPlayerFromText(image.description, undefined, cache)
+    const player = getPlayerFromText(
+      image.description,
+      image.data?.foundPlayer?.length
+        ? image.data.foundPlayer
+        : image.data?.mysteryPlayer,
+      cache
+    )
     if (!player) continue
     playerGroupedImages[player] = playerGroupedImages[player] ?? []
     playerGroupedImages[player].push(image)
   }
 
   for (const image of groupedImages[highestTagnumber - 1] ?? []) {
-    const player = getPlayerFromText(image.description, undefined, cache)
+    const player = getPlayerFromText(
+      image.description,
+      image.data?.foundPlayer?.length
+        ? image.data.foundPlayer
+        : image.data?.mysteryPlayer,
+      cache
+    )
     if (!player) continue
     playerGroupedImages[player] = playerGroupedImages[player] ?? []
     playerGroupedImages[player].push(image)
@@ -573,8 +590,8 @@ export const getGroupedTagsByPlayer = (
     if (images.length === 1) {
       playerGroupedTags.push(
         getBikeTagFromS3ImageSet(
-          isMysteryImage(images[0] as ImgurImage) ? images[0] : undefined,
-          isFoundImage(images[0] as ImgurImage) ? images[0] : undefined,
+          isMysteryImage(images[0]) ? images[0] : undefined,
+          isFoundImage(images[0]) ? images[0] : undefined,
           appendToTagData
         )
       )
@@ -600,7 +617,11 @@ export const getGroupedImagesByTagnumber = (
   const groupedImages: S3ImageMeta[][] = []
 
   ungroupedImages.forEach((image) => {
-    const tagnumbers = getTagNumbersFromText(image.description, [], cache)
+    const tagnumbers = getTagNumbersFromText(
+      image.description,
+      [image.data?.tagnumber],
+      cache
+    )
     const tagnumber = tagnumbers[0] // Assume the first is primary
 
     if (typeof tagnumber === 'number') {
@@ -687,6 +708,104 @@ export const getHashedPlayerSuffix = async (
     .slice(0, 6)
 }
 
+export const getMysteryMetadata = (
+  tag: Tag,
+  metadataOverrides: Record<string, any> = {}
+): string => {
+  const base = {
+    t: tag.tagnumber,
+    p: tag.playerId,
+    mp: tag.mysteryPlayer,
+    mt: tag.mysteryTime,
+    h: tag.hint,
+    d: tag.discussionUrl,
+    s: tag.shareUrl,
+    m: tag.mentionUrl,
+  }
+
+  const merged = { ...base, ...metadataOverrides }
+  return encodeMetadataValue(JSON.stringify(merged))
+}
+
+export const getFoundMetadata = (
+  tag: Tag,
+  metadataOverrides: Record<string, any> = {}
+): string => {
+  const base = {
+    t: tag.tagnumber,
+    p: tag.playerId,
+    fp: tag.foundPlayer,
+    ft: tag.foundTime,
+    fl: tag.foundLocation,
+    g: tag.gps,
+    c: tag.confirmedBoundary,
+  }
+
+  const merged = { ...base, ...metadataOverrides }
+  return encodeMetadataValue(JSON.stringify(merged))
+}
+
+export const getTagMetadata = (
+  mysteryMeta: string | undefined,
+  foundMeta?: string | undefined,
+  metadataOverrides: Record<string, any> = {}
+): Tag => {
+  const decodeJson = (meta?: string): Record<string, any> => {
+    if (!meta) return {}
+    try {
+      return JSON.parse(decodeMetadataValue(meta)) || {}
+    } catch {
+      return {}
+    }
+  }
+
+  const mystery = decodeJson(mysteryMeta)
+  const found = decodeJson(foundMeta)
+  const merged = {
+    tagnumber: mystery.t || found.t,
+    playerId: mystery.p || found.p,
+    mysteryPlayer: mystery.mp || '',
+    mysteryTime: mystery.mt || 0,
+    hint: mystery.h || '',
+    discussionUrl: mystery.d || '',
+    shareUrl: mystery.s || '',
+    mentionUrl: mystery.m || '',
+    foundPlayer: found.fp || '',
+    foundTime: found.ft || 0,
+    foundLocation: found.fl || '',
+    gps: found.g || {},
+    ...metadataOverrides,
+  }
+
+  if (typeof merged.tagnumber !== 'number') {
+    return null
+  }
+
+  return createTagObject(merged)
+}
+
+export const isMysteryImage = (image: S3ImageMeta): boolean => {
+  if (image?.data) {
+    return !!(
+      image.data.mysteryPlayer ||
+      image.data.mysteryTime ||
+      image.data.hint
+    )
+  }
+  return isImgurMysteryImage(image as ImgurImage)
+}
+
+export const isFoundImage = (image: S3ImageMeta): boolean => {
+  if (image?.data) {
+    return !!(
+      image.data.foundPlayer ||
+      image.data.foundTime ||
+      image.data.foundLocation
+    )
+  }
+  return isImugrFoundImage(image as ImgurImage)
+}
+
 export interface S3UploadPayload {
   region: string
   game: string // e.g., 'denver' — used to build bucket name
@@ -706,6 +825,7 @@ export type queueTagPayload = Partial<Tag> &
 export type updateTagPayload = Partial<Tag> &
   Partial<S3UploadPayload> &
   CommonPayloadData
+
 export const supportedImageExtensions = [
   '.jpg',
   '.jpeg',

--- a/src/aws/updateTag.ts
+++ b/src/aws/updateTag.ts
@@ -5,18 +5,14 @@ import { createTagObject } from '../common/data'
 import { AvailableApis, HttpStatusCode } from '../common/enums'
 import { Tag } from '../common/schema'
 import {
+  getFoundMetadata,
+  getMysteryMetadata,
   loadIndex,
   resizeAndSaveVariants,
   saveIndex,
   type updateTagPayload,
 } from './helpers'
-import { getKeyFromUrl, encodeMetadataValue } from './helpers'
-import {
-  getImgurFoundTitleFromBikeTagData,
-  getImgurFoundDescriptionFromBikeTagData,
-  getImgurMysteryTitleFromBikeTagData,
-  getImgurMysteryDescriptionFromBikeTagData,
-} from '../common/getters'
+import { getKeyFromUrl } from './helpers'
 import TinyCache from 'tinycache'
 
 export async function updateTag(
@@ -26,10 +22,14 @@ export async function updateTag(
 ): Promise<BikeTagApiResponse<Tag>> {
   payload.folder = payload.folder ?? 'main'
 
+  const logVerbose = payload.verbose ? console.log : () => {}
+
   let success = true
   let error: string | undefined
 
   const bucket = `${payload.game}-biketag`
+  logVerbose('[updateTag] Checking for existing tag in', payload.folder)
+
   const tagExistsResponse = await this.getTags(
     {
       game: payload.game,
@@ -50,9 +50,11 @@ export async function updateTag(
   const needsFound = !!(payload.foundImageUrl?.length || payload.foundImage)
 
   if (needsMystery || needsFound) {
+    logVerbose('[updateTag] Uploading new images...')
     const uploadResponse = await this.uploadTagImage(payload)
 
     if (uploadResponse.success) {
+      logVerbose('[updateTag] Image upload successful.')
       payload.mysteryImageUrl = uploadResponse.data.mysteryImageUrl
       payload.mysteryTime = uploadResponse.data.mysteryTime
       payload.foundImageUrl = uploadResponse.data.foundImageUrl
@@ -62,15 +64,16 @@ export async function updateTag(
     } else {
       success = false
       error = uploadResponse.error
+      logVerbose('[updateTag] Upload failed:', error)
     }
   } else if (existingTag) {
-    // Metadata-only update
+    logVerbose('[updateTag] Performing metadata-only update...')
     payload = { ...existingTag, ...payload }
 
-    // Explicit metadata refresh for mystery image
     if (existingTag.mysteryImageUrl) {
       const mysteryKey = getKeyFromUrl(existingTag.mysteryImageUrl)
       try {
+        logVerbose('[updateTag] Updating metadata for mystery image...')
         await client.send(
           new CopyObjectCommand({
             Bucket: bucket,
@@ -79,12 +82,7 @@ export async function updateTag(
             ACL: 'public-read',
             MetadataDirective: 'REPLACE',
             Metadata: {
-              title: encodeMetadataValue(
-                getImgurMysteryTitleFromBikeTagData(payload as Tag).trim()
-              ),
-              description: encodeMetadataValue(
-                getImgurMysteryDescriptionFromBikeTagData(payload as Tag).trim()
-              ),
+              data: getMysteryMetadata(payload as Tag),
             },
           })
         )
@@ -93,13 +91,14 @@ export async function updateTag(
         error =
           (error ?? '') +
           ` Failed to update metadata for mystery image: ${err.message || err}`
+        logVerbose('[updateTag] Mystery metadata update failed:', err)
       }
     }
 
-    // Explicit metadata refresh for found image
     if (existingTag.foundImageUrl) {
       const foundKey = getKeyFromUrl(existingTag.foundImageUrl)
       try {
+        logVerbose('[updateTag] Updating metadata for found image...')
         await client.send(
           new CopyObjectCommand({
             Bucket: bucket,
@@ -108,12 +107,7 @@ export async function updateTag(
             ACL: 'public-read',
             MetadataDirective: 'REPLACE',
             Metadata: {
-              title: encodeMetadataValue(
-                getImgurFoundTitleFromBikeTagData(payload as Tag).trim()
-              ),
-              description: encodeMetadataValue(
-                getImgurFoundDescriptionFromBikeTagData(payload as Tag).trim()
-              ),
+              data: getFoundMetadata(payload as Tag),
             },
           })
         )
@@ -122,16 +116,18 @@ export async function updateTag(
         error =
           (error ?? '') +
           ` Failed to update metadata for found image: ${err.message || err}`
+        logVerbose('[updateTag] Found metadata update failed:', err)
       }
     }
   } else {
     success = false
     error = `Tag ${payload.tagnumber} not found in folder ${payload.folder}`
+    logVerbose('[updateTag] Tag not found for metadata update.')
   }
 
   if (success) {
     try {
-      // 1️⃣ Load current index
+      logVerbose('[updateTag] Loading existing index...')
       let index: Tag[] = await loadIndex(
         client,
         bucket,
@@ -140,32 +136,35 @@ export async function updateTag(
       )
       const updatedTag = createTagObject(payload)
 
-      // 2️⃣ Replace or add tag
       const existingIndex = index.findIndex(
         (t) => t.tagnumber === updatedTag.tagnumber
       )
       if (existingIndex !== -1) {
         index[existingIndex] = updatedTag
+        logVerbose('[updateTag] Replacing existing tag in index.')
       } else {
         index.push(updatedTag)
+        logVerbose('[updateTag] Adding new tag to index.')
       }
 
-      // 3️⃣ Save new index.json atomically
+      logVerbose('[updateTag] Saving updated index...')
       await saveIndex(client, bucket, payload.folder, index)
     } catch (err: any) {
       success = false
       error =
         (error ?? '') +
         ` Failed to atomically update index: ${err.message || err}`
+      logVerbose('[updateTag] Index update failed:', err)
     }
   }
 
   if (success && payload.resize === true) {
-    let resizeErrors: string[] = []
     const tag = createTagObject(payload)
+    let resizeErrors: string[] = []
 
     if (payload.mysteryImageUrl) {
       try {
+        logVerbose('[updateTag] Resizing mystery image...')
         await resizeAndSaveVariants({
           client,
           tag,
@@ -178,11 +177,13 @@ export async function updateTag(
         resizeErrors.push(
           `Failed to resize mystery image: ${resizeErr.message || resizeErr}`
         )
+        logVerbose('[updateTag] Resize failed for mystery image:', resizeErr)
       }
     }
 
     if (payload.foundImageUrl) {
       try {
+        logVerbose('[updateTag] Resizing found image...')
         await resizeAndSaveVariants({
           client,
           tag,
@@ -195,6 +196,7 @@ export async function updateTag(
         resizeErrors.push(
           `Failed to resize found image: ${resizeErr.message || resizeErr}`
         )
+        logVerbose('[updateTag] Resize failed for found image:', resizeErr)
       }
     }
 

--- a/src/aws/uploadTagImage.ts
+++ b/src/aws/uploadTagImage.ts
@@ -1,12 +1,6 @@
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
 import { createTagObject } from '../common/data'
 import { AvailableApis, HttpStatusCode } from '../common/enums'
-import {
-  getImgurMysteryTitleFromBikeTagData,
-  getImgurFoundTitleFromBikeTagData,
-  getImgurMysteryDescriptionFromBikeTagData,
-  getImgurFoundDescriptionFromBikeTagData,
-} from '../common/getters'
 import { BikeTagApiResponse } from '../common/types'
 import { Tag } from '../common/schema'
 import {
@@ -15,7 +9,8 @@ import {
   getBikeTagImageKey,
   moveImage,
   normalizeUploadBody,
-  encodeMetadataValue,
+  getMysteryMetadata,
+  getFoundMetadata,
 } from './helpers'
 import {
   getContentTypeFromExtension,
@@ -26,6 +21,8 @@ export async function uploadTagImage(
   client: S3Client,
   payload: uploadTagImagePayload
 ): Promise<BikeTagApiResponse<Tag>> {
+  const logVerbose = payload.verbose ? console.log : () => {}
+
   let success = true
   const errors: string[] = []
 
@@ -33,6 +30,7 @@ export async function uploadTagImage(
     url?: string
   ): Promise<{ blob: Blob; contentType: string } | undefined> => {
     if (!url) return
+    logVerbose('[uploadTagImage] Downloading image from', url)
     const res = await fetch(url)
     if (!res.ok) throw new Error(`Failed to download image: ${url}`)
     const contentType = res.headers.get('content-type') || 'image/jpeg'
@@ -43,30 +41,27 @@ export async function uploadTagImage(
   const tryUploadImage = async (
     type: 'mystery' | 'found'
   ): Promise<string | undefined> => {
+    logVerbose(`[uploadTagImage] Processing ${type} image...`)
+
     const urlField = `${type}ImageUrl`
     const blobField = `${type}Image`
 
     const bucket = `${payload.game}-biketag`
     const region = payload.region ?? 'nyc3'
     const folder = payload.folder ?? 'queue'
-
     const player =
       type === 'mystery' ? payload.mysteryPlayer : payload.foundPlayer
 
     let contentType = payload.contentType
-
     const existingUrl = payload[urlField]
     const currentKey = existingUrl ? getKeyFromUrl(existingUrl) : ''
-
     const isBucketUrl = existingUrl?.includes(`${bucket}.${region}`)
 
     if (isBucketUrl) {
       // 🔔 Ensure inferredContentType is populated before key comparison
       if (!contentType) {
         const ext = getExtensionFromUrl(existingUrl)
-        if (ext) {
-          contentType = getContentTypeFromExtension(ext)
-        }
+        if (ext) contentType = getContentTypeFromExtension(ext)
       }
 
       // If it's already our bucket, but wrong key (wrong folder, missing hash, etc.)
@@ -78,21 +73,26 @@ export async function uploadTagImage(
         contentType,
         folder
       )
-
       const expectedUrl = `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${expectedKey}`
 
       if (currentKey === expectedKey) {
-        return existingUrl // Correct location → nothing to do.
+        logVerbose(
+          `[uploadTagImage] ${type} image already in correct location.`
+        )
+        return existingUrl
       }
 
-      // 🔧 Move it if it's not at the right key
+      logVerbose(`[uploadTagImage] Moving ${type} image to correct key...`)
       const moveResult = await moveImage(
         client,
         bucket,
         currentKey,
         expectedKey
       )
-      if (moveResult.success) return expectedUrl
+      if (moveResult.success) {
+        logVerbose(`[uploadTagImage] Moved ${type} image successfully.`)
+        return expectedUrl
+      }
 
       success = false
       errors.push(
@@ -103,9 +103,11 @@ export async function uploadTagImage(
       return undefined
     }
 
-    // If not our bucket → download before inferring key
     if (!payload[blobField] && existingUrl) {
       try {
+        logVerbose(
+          `[uploadTagImage] Downloading ${type} image from external URL...`
+        )
         const result = await maybeDownloadImage(existingUrl)
         if (result) {
           payload[blobField] = result.blob
@@ -120,9 +122,7 @@ export async function uploadTagImage(
 
     if (!contentType && existingUrl) {
       const ext = getExtensionFromUrl(existingUrl)
-      if (ext) {
-        contentType = getContentTypeFromExtension(ext)
-      }
+      if (ext) contentType = getContentTypeFromExtension(ext)
     }
 
     const key = await getBikeTagImageKey(
@@ -133,7 +133,6 @@ export async function uploadTagImage(
       contentType,
       folder
     )
-
     const fullUrl = `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${key}`
 
     if (!payload[blobField]) {
@@ -148,18 +147,9 @@ export async function uploadTagImage(
       payload.foundTime = Math.floor(Date.now() / 1000)
     }
 
-    const title =
-      type === 'mystery'
-        ? getImgurMysteryTitleFromBikeTagData(payload as Tag)
-        : getImgurFoundTitleFromBikeTagData(payload as Tag)
-
-    const description =
-      type === 'mystery'
-        ? getImgurMysteryDescriptionFromBikeTagData(payload as Tag)
-        : getImgurFoundDescriptionFromBikeTagData(payload as Tag)
-
     try {
       if (typeof window === 'undefined') {
+        logVerbose(`[uploadTagImage] Uploading ${type} image to S3 (Node)...`)
         await client.send(
           new PutObjectCommand({
             Bucket: bucket,
@@ -168,12 +158,17 @@ export async function uploadTagImage(
             ContentType: contentType,
             ACL: 'public-read',
             Metadata: {
-              title: encodeMetadataValue(title.trim()),
-              description: encodeMetadataValue(description.trim()),
+              data:
+                type === 'mystery'
+                  ? getMysteryMetadata(payload as Tag)
+                  : getFoundMetadata(payload as Tag),
             },
           })
         )
       } else if (this.fetchSignedUrl && this.plainFetcher) {
+        logVerbose(
+          `[uploadTagImage] Uploading ${type} image to S3 (browser via signed URL)...`
+        )
         const signedUrlResponse = await this.fetchSignedUrl({
           key,
           p_id: payload.playerId,
@@ -189,19 +184,24 @@ export async function uploadTagImage(
           method: 'PUT',
           headers: {
             'Content-Type': contentType,
-            'x-amz-meta-title': encodeMetadataValue(title.trim()),
-            'x-amz-meta-description': encodeMetadataValue(description.trim()),
+            'x-amz-meta-data':
+              type === 'mystery'
+                ? getMysteryMetadata(payload as Tag)
+                : getFoundMetadata(payload as Tag),
             'x-amz-acl': 'public-read',
           },
           data: await normalizeUploadBody(payload[blobField]),
         })
       }
-    } catch (uploadError) {
+    } catch (uploadError: any) {
       success = false
       errors.push(`Failed to upload ${type} image: ${uploadError.message}`)
       return undefined
     }
 
+    logVerbose(
+      `[uploadTagImage] Successfully uploaded ${type} image to ${fullUrl}`
+    )
     return fullUrl
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -314,6 +314,10 @@ export class BikeTagClient {
         break
     }
 
+    options.verbose =
+      options.verbose !== undefined
+        ? options.verbose
+        : this.biketagConfig?.verbose
     options.host = options.host ?? this.biketagConfig?.host
     options.cached = options.cached ?? this.biketagConfig?.cached
     options.concise =

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -641,22 +641,23 @@ export const getBikeTagFromS3ImageSet = (
     mentionUrl = mysteryImage.data?.mentionUrl ?? ''
     shareUrl = mysteryImage.data?.shareUrl ?? ''
   } else if (foundImage.data?.tagnumber) {
+    tagnumber = foundImage.data.tagnumber ?? 0
     foundImageUrl = foundImage.url
-    foundPlayer = foundImage.data?.foundPlayer ?? ''
-    foundTime = foundImage.data?.foundTime ?? 0
-    foundLocation = foundImage.data?.foundLocation ?? ''
-    confirmedBoundary = foundImage.data?.confirmedBoundary ?? false
-    hint = mysteryImage.data?.hint ?? ''
-    gps = foundImage.data?.gps ?? { lat: 0, long: 0, alt: 0 }
+    foundPlayer = foundImage.data.foundPlayer ?? ''
+    foundTime = foundImage.data.foundTime ?? 0
+    foundLocation = foundImage.data.foundLocation ?? ''
+    confirmedBoundary = foundImage.data.confirmedBoundary ?? false
+    gps = foundImage.data.gps ?? { lat: 0, long: 0, alt: 0 }
   } else if (mysteryImage.data?.tagnumber) {
-    tagnumber = mysteryImage.data.tagnumber ?? foundImage.data.tagnumber ?? 0
+    tagnumber = mysteryImage.data.tagnumber ?? 0
     mysteryImageUrl = mysteryImage.url
-    mysteryPlayer = mysteryImage.data?.mysteryPlayer ?? ''
-    mysteryTime = mysteryImage.data?.mysteryTime ?? 0
-    discussionUrl = mysteryImage.data?.discussionUrl ?? ''
-    mentionUrl = mysteryImage.data?.mentionUrl ?? ''
-    shareUrl = mysteryImage.data?.shareUrl ?? ''
-    playerId = foundImage.data?.playerId ?? mysteryImage.data?.playerId
+    mysteryPlayer = mysteryImage.data.mysteryPlayer ?? ''
+    mysteryTime = mysteryImage.data.mysteryTime ?? 0
+    hint = mysteryImage.data.hint ?? ''
+    discussionUrl = mysteryImage.data.discussionUrl ?? ''
+    mentionUrl = mysteryImage.data.mentionUrl ?? ''
+    shareUrl = mysteryImage.data.shareUrl ?? ''
+    playerId = mysteryImage.data.playerId
   }
 
   if (foundImage && !foundImageUrl) {

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -626,21 +626,21 @@ export const getBikeTagFromS3ImageSet = (
 
   if (foundImage.data?.tagnumber && mysteryImage.data?.tagnumber) {
     tagnumber = mysteryImage.data.tagnumber ?? foundImage.data.tagnumber ?? 0
-    playerId = foundImage.data?.playerId ?? mysteryImage.data?.playerId
+    playerId = foundImage.data.playerId ?? mysteryImage.data.playerId
     mysteryImageUrl = mysteryImage.url
-    mysteryPlayer = mysteryImage.data?.mysteryPlayer ?? ''
-    mysteryTime = mysteryImage.data?.mysteryTime ?? 0
+    mysteryPlayer = mysteryImage.data.mysteryPlayer ?? ''
+    mysteryTime = mysteryImage.data.mysteryTime ?? 0
     foundImageUrl = foundImage.url
-    foundPlayer = foundImage.data?.foundPlayer ?? ''
-    foundTime = foundImage.data?.foundTime ?? 0
-    foundLocation = foundImage.data?.foundLocation ?? ''
-    confirmedBoundary = foundImage.data?.confirmedBoundary ?? false
-    hint = mysteryImage.data?.hint ?? ''
-    gps = foundImage.data?.gps ?? { lat: 0, long: 0, alt: 0 }
-    discussionUrl = mysteryImage.data?.discussionUrl ?? ''
-    mentionUrl = mysteryImage.data?.mentionUrl ?? ''
-    shareUrl = mysteryImage.data?.shareUrl ?? ''
-  } else if (foundImage.data?.tagnumber) {
+    foundPlayer = foundImage.data.foundPlayer ?? ''
+    foundTime = foundImage.data.foundTime ?? 0
+    foundLocation = foundImage.data.foundLocation ?? ''
+    confirmedBoundary = foundImage.data.confirmedBoundary ?? false
+    hint = mysteryImage.data.hint ?? ''
+    gps = foundImage.data.gps ?? { lat: 0, long: 0, alt: 0 }
+    discussionUrl = mysteryImage.data.discussionUrl ?? ''
+    mentionUrl = mysteryImage.data.mentionUrl ?? ''
+    shareUrl = mysteryImage.data.shareUrl ?? ''
+  } else if (foundImage.data.tagnumber) {
     tagnumber = foundImage.data.tagnumber ?? 0
     foundImageUrl = foundImage.url
     foundPlayer = foundImage.data.foundPlayer ?? ''

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -603,17 +603,64 @@ export const getBikeTagFromS3ImageSet = (
 ): Tag => {
   if (!foundImage && !mysteryImage) return null as Tag
 
-  let foundImageLink, foundImageDescription, foundImageTitle, foundTime
-  let mysteryImageLink, mysteryImageDescription, mysteryImageTitle, mysteryTime
+  /// TODO: remove the image and description from the S3ImageMeta interface
+  let foundImageDescription, foundImageTitle
+  let mysteryImageDescription, mysteryImageTitle
+  let game = opts?.game ?? '',
+    tagnumber = 0,
+    slug
   let hint,
+    foundTime,
+    mysteryTime,
+    mysteryImageUrl,
+    foundImageUrl,
+    playerId,
+    gps,
+    mentionUrl,
+    shareUrl,
     discussionUrl,
     mysteryPlayer,
     foundPlayer,
     foundLocation,
     confirmedBoundary
 
-  if (foundImage) {
-    foundImageLink = foundImage.url
+  if (foundImage.data?.tagnumber && mysteryImage.data?.tagnumber) {
+    tagnumber = mysteryImage.data.tagnumber ?? foundImage.data.tagnumber ?? 0
+    playerId = foundImage.data?.playerId ?? mysteryImage.data?.playerId
+    mysteryImageUrl = mysteryImage.url
+    mysteryPlayer = mysteryImage.data?.mysteryPlayer ?? ''
+    mysteryTime = mysteryImage.data?.mysteryTime ?? 0
+    foundImageUrl = foundImage.url
+    foundPlayer = foundImage.data?.foundPlayer ?? ''
+    foundTime = foundImage.data?.foundTime ?? 0
+    foundLocation = foundImage.data?.foundLocation ?? ''
+    confirmedBoundary = foundImage.data?.confirmedBoundary ?? false
+    hint = mysteryImage.data?.hint ?? ''
+    gps = foundImage.data?.gps ?? { lat: 0, long: 0, alt: 0 }
+    discussionUrl = mysteryImage.data?.discussionUrl ?? ''
+    mentionUrl = mysteryImage.data?.mentionUrl ?? ''
+    shareUrl = mysteryImage.data?.shareUrl ?? ''
+  } else if (foundImage.data?.tagnumber) {
+    foundImageUrl = foundImage.url
+    foundPlayer = foundImage.data?.foundPlayer ?? ''
+    foundTime = foundImage.data?.foundTime ?? 0
+    foundLocation = foundImage.data?.foundLocation ?? ''
+    confirmedBoundary = foundImage.data?.confirmedBoundary ?? false
+    hint = mysteryImage.data?.hint ?? ''
+    gps = foundImage.data?.gps ?? { lat: 0, long: 0, alt: 0 }
+  } else if (mysteryImage.data?.tagnumber) {
+    tagnumber = mysteryImage.data.tagnumber ?? foundImage.data.tagnumber ?? 0
+    mysteryImageUrl = mysteryImage.url
+    mysteryPlayer = mysteryImage.data?.mysteryPlayer ?? ''
+    mysteryTime = mysteryImage.data?.mysteryTime ?? 0
+    discussionUrl = mysteryImage.data?.discussionUrl ?? ''
+    mentionUrl = mysteryImage.data?.mentionUrl ?? ''
+    shareUrl = mysteryImage.data?.shareUrl ?? ''
+    playerId = foundImage.data?.playerId ?? mysteryImage.data?.playerId
+  }
+
+  if (foundImage && !foundImageUrl) {
+    foundImageUrl = foundImage.url
     foundImageDescription = foundImage.description
     foundImageTitle = foundImage.title
     foundTime = getTimeFromText(foundImageDescription)
@@ -622,8 +669,8 @@ export const getBikeTagFromS3ImageSet = (
     confirmedBoundary = getConfirmedBoundaryFromText(foundImageTitle)
   }
 
-  if (mysteryImage) {
-    mysteryImageLink = mysteryImage.url
+  if (mysteryImage && !mysteryImageUrl) {
+    mysteryImageUrl = mysteryImage.url
     mysteryImageDescription = mysteryImage.description
     mysteryImageTitle = mysteryImage.title
     mysteryTime = getTimeFromText(mysteryImageDescription)
@@ -632,21 +679,23 @@ export const getBikeTagFromS3ImageSet = (
     mysteryPlayer = getPlayerFromText(mysteryImageDescription)
   }
 
-  const game = opts?.game || ''
-  const tagnumber = mysteryImageDescription
-    ? getTagNumbersFromText(mysteryImageDescription)[0]
-    : getTagNumbersFromText(foundImageDescription)[0]
+  tagnumber =
+    tagnumber !== 0 && mysteryImageDescription
+      ? getTagNumbersFromText(mysteryImageDescription)[0]
+      : getTagNumbersFromText(foundImageDescription)[0]
+  slug = constructTagNumberSlug(tagnumber, game)
 
-  const slug = constructTagNumberSlug(tagnumber, game)
-  const playerId =
-    getPlayerIdFromText(mysteryImageTitle) ||
+  playerId =
+    playerId ??
+    getPlayerIdFromText(mysteryImageTitle) ??
     getPlayerIdFromText(foundImageTitle)
 
-  let gps = foundImageDescription
-    ? getGPSLocationFromText(foundImageDescription)
-    : getGPSLocationFromText(mysteryImageTitle)
+  gps =
+    (gps ?? foundImageDescription)
+      ? getGPSLocationFromText(foundImageDescription)
+      : getGPSLocationFromText(mysteryImageTitle)
 
-  if (gps.lat === 0 && gps.long === 0 && foundImageTitle) {
+  if (gps.lat === 0 && gps.long === 0 && foundImageTitle?.length) {
     gps = getGPSLocationFromText(foundImageTitle)
   }
 
@@ -663,6 +712,8 @@ export const getBikeTagFromS3ImageSet = (
     slug,
     game,
     discussionUrl,
+    shareUrl,
+    mentionUrl,
     foundLocation,
     mysteryPlayer,
     foundPlayer,
@@ -671,8 +722,8 @@ export const getBikeTagFromS3ImageSet = (
     hint,
     playerId,
     confirmedBoundary,
-    mysteryImageUrl: mysteryImageLink,
-    foundImageUrl: foundImageLink,
+    mysteryImageUrl,
+    foundImageUrl,
     gps,
   }
 }

--- a/src/common/methods.ts
+++ b/src/common/methods.ts
@@ -274,6 +274,7 @@ export const createBikeTagCredentials = (
   return {
     game: credentials.game?.length ? credentials.game : defaults.game,
     host: credentials.host?.length ? credentials.host : defaults.host,
+    verbose: credentials.verbose,
     cached:
       typeof credentials.cached !== 'undefined'
         ? credentials.cached

--- a/src/common/payloads.ts
+++ b/src/common/payloads.ts
@@ -38,7 +38,8 @@ export type deleteTagPayload = {
   hash?: string
   folder?: string
   region?: string
-} & Partial<Tag>
+} & Partial<Tag> &
+  CommonPayloadData
 
 export type archiveTagPayload = {
   archivehash?: string

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -3,6 +3,7 @@ export { Payload } from 'imgur/dist/common/types'
 import { AvailableApis, Errors } from '../common/enums'
 import { ImgurCredentials as ImgurApiCredentials } from 'imgur'
 import { S3Client } from '@aws-sdk/client-s3'
+import { Tag } from './schema'
 
 export type RequireAtLeastOne<T> = {
   [K in keyof T]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<keyof T, K>>>
@@ -48,6 +49,7 @@ export interface CommonData {
   cached?: boolean
   region?: string
   reindex?: boolean
+  verbose?: boolean
 }
 
 export type CommonPayloadData = CommonData
@@ -91,6 +93,7 @@ export type ApiOptions = RequireAtLeastOne<{
   account?: string
   concise?: boolean
   cached?: boolean
+  verbose?: boolean
   region?: string
 }>
 
@@ -166,8 +169,10 @@ export interface StatsReportData {
   gameLongestTimeBetweenTags: gameLongestTimeBetweenTagsData
 }
 
+/// TODO: remove the image and description from the S3ImageMeta interface
 export interface S3ImageMeta {
   url?: string
   title?: string
   description?: string
+  data?: Partial<Tag>
 }


### PR DESCRIPTION
now saving the tagdata as a stringified JSON object instead of title and description

This should be backwards compatible with having stored images with titles and descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a unified metadata format for tag images, embedding structured JSON metadata directly in image files.
  * Added support for verbose logging across AWS operations and client configuration, enabling detailed runtime diagnostics when enabled.
  * Extended API and payload types to support the new metadata format and verbose options.

* **Improvements**
  * Enhanced metadata extraction and assignment logic for tags, improving accuracy and consistency of tag information.
  * Updated client and credential creation to propagate verbose settings throughout the system.

* **Bug Fixes**
  * Improved error handling and logging for AWS operations, making troubleshooting easier.

* **Refactor**
  * Replaced Imgur-specific metadata handling with a unified approach for all storage backends.
  * Streamlined and reorganized logic for extracting and assigning tag-related fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->