### PR TITLE
fix(aws): now using whatever tagnumber comes in for the call to queueTag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biketag",
-  "version": "3.5.30",
+  "version": "3.5.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biketag",
-      "version": "3.5.30",
+      "version": "3.5.31",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.839.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biketag",
-  "version": "3.5.30",
+  "version": "3.5.31",
   "description": "The Javascript client API for BikeTag Games",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/aws/queueTag.ts
+++ b/src/aws/queueTag.ts
@@ -53,7 +53,6 @@ export async function queueTag(
 
   if (isCompleteQueuedTag) {
     const isBrowserRequest = typeof window !== 'undefined'
-    payload.tagnumber = payload.tagnumber - 1
     const updateResponse = isBrowserRequest
       ? await this.biketagUpdate(payload, cache)
       : await this.updateTag(payload, cache)


### PR DESCRIPTION
this will make it so that the tag is the current tagnumber for when a player uploads the found image, but then the tagnumber will update to the next tagnumber when the player has added their mystery tag image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an issue where the tag number was incorrectly decremented when completing a queued tag.

* **Chores**
  * Updated the package version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->