### PR TITLE
fix(aws): pair queue submissions by playerId instead of display name

### DIFF
--- a/src/aws/getQueue.ts
+++ b/src/aws/getQueue.ts
@@ -1,6 +1,6 @@
-import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { S3Client } from '@aws-sdk/client-s3'
 import { getQueuePayload } from '../common/payloads'
-import { BikeTagApiResponse, S3ImageMeta } from '../common/types'
+import { BikeTagApiResponse } from '../common/types'
 import { Tag } from '../common/schema'
 import { AvailableApis, HttpStatusCode } from '../common/enums'
 import {
@@ -8,10 +8,7 @@ import {
   saveIndex,
   resizeAndSaveVariants,
   listAllS3Objects,
-  getGroupedImagesByTagnumber,
-  getGroupedTagsByPlayer,
-  decodeMetadataValue,
-  getTagMetadata,
+  loadQueueTagsFromImages,
 } from './helpers'
 import { sortTags } from '../common/methods'
 
@@ -38,7 +35,7 @@ export async function getQueue(
           client,
           bucket,
           folder,
-          region,
+          region!,
           cached,
           reindex
         )
@@ -58,38 +55,13 @@ export async function getQueue(
       const files = list.map((obj) => obj.Key).filter(Boolean) as string[]
       logVerbose(`[getQueue] Found ${files.length} files in ${folder}/`)
 
-      const metaList: S3ImageMeta[] = []
-
-      for (const key of files) {
-        // Skip variants
-        if (/_medium\.webp$|_small\.webp$/i.test(key)) continue
-
-        const match = key.match(
-          new RegExp(
-            `${folder}/(.+?)--(mystery|found)--([a-z0-9]+)\\.(webp|jpg|jpeg|png)$`,
-            'i'
-          )
-        )
-        if (!match) continue
-
-        logVerbose('[getQueue] Getting metadata for', key)
-        const head = await client.send(
-          new HeadObjectCommand({ Bucket: bucket, Key: key })
-        )
-
-        const meta: S3ImageMeta = {
-          url: `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${key}`,
-          title: decodeMetadataValue(head.Metadata?.title || ''),
-          description: decodeMetadataValue(head.Metadata?.description || ''),
-          data: getTagMetadata(head.Metadata?.data),
-        }
-
-        metaList.push(meta)
-      }
-
-      logVerbose(`[getQueue] Collected metadata for ${metaList.length} images`)
-      const groupedImages = getGroupedImagesByTagnumber(metaList)
-      queuedTags = getGroupedTagsByPlayer(groupedImages, { game })
+      logVerbose('[getQueue] Rebuilding queue tags from images...')
+      queuedTags = await loadQueueTagsFromImages(
+        client,
+        bucket,
+        folder,
+        region!
+      )
       logVerbose(`[getQueue] Grouped into ${queuedTags.length} tag(s)`)
 
       if (resize) {

--- a/src/aws/helpers.ts
+++ b/src/aws/helpers.ts
@@ -13,7 +13,7 @@ import {
 import { Tag } from '../common/schema'
 import {
   getBikeTagFromS3ImageSet,
-  getPlayerFromText,
+  getPlayerGroupingKey,
   getTagNumbersFromText,
 } from '../common/getters'
 import { Readable } from 'form-data'
@@ -110,6 +110,81 @@ export const streamToString = async (stream: any): Promise<string> => {
   throw new Error('Unsupported stream type')
 }
 
+export const parseTagnumberFromQueueKey = (key: string): number | undefined => {
+  const match = key.match(/-tag-(\d+)--(?:mystery|found)--/i)
+  return match ? parseInt(match[1], 10) : undefined
+}
+
+export const collectQueueImageMetaList = async (
+  client: S3Client,
+  bucket: string,
+  folder: string,
+  region: string
+): Promise<S3ImageMeta[]> => {
+  const list = await listAllS3Objects(client, {
+    Bucket: bucket,
+    Prefix: `${folder}/`,
+  })
+
+  const metaList: S3ImageMeta[] = []
+
+  for (const obj of list) {
+    const key = obj.Key
+    if (!key) continue
+    if (/_medium\.webp$|_small\.webp$/i.test(key)) continue
+
+    const match = key.match(
+      new RegExp(
+        `${folder}/(.+?)--(mystery|found)--([a-z0-9]+)\\.(webp|jpg|jpeg|png)$`,
+        'i'
+      )
+    )
+    if (!match) continue
+
+    const head = await client.send(
+      new HeadObjectCommand({ Bucket: bucket, Key: key })
+    )
+
+    const parsed = getTagMetadata(head.Metadata?.data)
+    const tagnumberFromKey = parseTagnumberFromQueueKey(key)
+    const data =
+      parsed ??
+      (typeof tagnumberFromKey === 'number'
+        ? ({ tagnumber: tagnumberFromKey } as Partial<Tag>)
+        : undefined)
+
+    if (!data) continue
+
+    metaList.push({
+      url: `https://${bucket}.${region}.cdn.digitaloceanspaces.com/${key}`,
+      title: decodeMetadataValue(head.Metadata?.title || ''),
+      description: decodeMetadataValue(head.Metadata?.description || ''),
+      data,
+    })
+  }
+
+  return metaList
+}
+
+/** Rebuild queue tags by pairing submitter images across adjacent tag numbers. */
+export const loadQueueTagsFromImages = async (
+  client: S3Client,
+  bucket: string,
+  folder: string,
+  region: string,
+  cache?: typeof TinyCache
+): Promise<Tag[]> => {
+  const game = bucket.replace(/-biketag$/i, '')
+  const metaList = await collectQueueImageMetaList(
+    client,
+    bucket,
+    folder,
+    region
+  )
+  const groupedImages = getGroupedImagesByTagnumber(metaList, cache)
+  return getGroupedTagsByPlayer(groupedImages, { game }, cache)
+}
+
 export const loadIndex = async (
   client: S3Client,
   bucket: string,
@@ -180,6 +255,10 @@ const loadIndexFromImages = async (
 ): Promise<Tag[]> => {
   if (!region) {
     throw new Error('Missing or invalid region when calling loadIndex')
+  }
+
+  if (folder === 'queue') {
+    return loadQueueTagsFromImages(client, bucket, folder, region)
   }
 
   const prefix = `${folder}/`
@@ -565,26 +644,14 @@ export const getGroupedTagsByPlayer = (
 
   // Group player images from the current and previous round
   for (const image of groupedImages[highestTagnumber] ?? []) {
-    const player = getPlayerFromText(
-      image.description,
-      image.data?.foundPlayer?.length
-        ? image.data.foundPlayer
-        : image.data?.mysteryPlayer,
-      cache
-    )
+    const player = getPlayerGroupingKey(image, cache)
     if (!player) continue
     playerGroupedImages[player] = playerGroupedImages[player] ?? []
     playerGroupedImages[player].push(image)
   }
 
   for (const image of groupedImages[highestTagnumber - 1] ?? []) {
-    const player = getPlayerFromText(
-      image.description,
-      image.data?.foundPlayer?.length
-        ? image.data.foundPlayer
-        : image.data?.mysteryPlayer,
-      cache
-    )
+    const player = getPlayerGroupingKey(image, cache)
     if (!player) continue
     playerGroupedImages[player] = playerGroupedImages[player] ?? []
     playerGroupedImages[player].push(image)
@@ -625,8 +692,8 @@ export const getGroupedImagesByTagnumber = (
 
   ungroupedImages.forEach((image) => {
     const tagnumbers = getTagNumbersFromText(
-      image.description,
-      [image.data?.tagnumber],
+      image.description!,
+      [image.data?.tagnumber!],
       cache
     )
     const tagnumber = tagnumbers[0] // Assume the first is primary

--- a/src/aws/queueTag.ts
+++ b/src/aws/queueTag.ts
@@ -3,6 +3,7 @@ import { BikeTagApiResponse } from '../common/types'
 import { Tag } from '../common/schema'
 import { AvailableApis, HttpStatusCode } from '../common/enums'
 import { createTagObject } from '../common/data'
+import { getTagPlayerIdentity } from '../common/getters'
 import { queueTagPayload } from './helpers'
 import TinyCache from 'tinycache'
 
@@ -20,9 +21,12 @@ export async function queueTag(
 
   const isCompleteQueuedTag = payload.mysteryImageUrl && payload.foundImageUrl
 
+  const playerIdentity = getTagPlayerIdentity(payload)
+
   const playerAlreadyQueuedError =
     !isCompleteQueuedTag &&
-    queuedTags.some((t) => t.foundPlayer === payload.foundPlayer)
+    !!playerIdentity &&
+    queuedTags.some((t) => getTagPlayerIdentity(t) === playerIdentity)
 
   if (playerAlreadyQueuedError) {
     return {
@@ -34,8 +38,17 @@ export async function queueTag(
     }
   }
 
+  const previousMysteryIdentity = currentTag
+    ? getTagPlayerIdentity({
+        playerId: currentTag.playerId,
+        mysteryPlayer: currentTag.mysteryPlayer,
+      })
+    : null
+
   const playerIsPreviousMystery =
-    currentTag?.mysteryPlayer === payload.foundPlayer
+    !!playerIdentity &&
+    !!previousMysteryIdentity &&
+    playerIdentity === previousMysteryIdentity
 
   if (playerIsPreviousMystery) {
     return {

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -132,12 +132,37 @@ export const getPlayerFromText = (
   return player
 }
 
+/** Stable key for pairing queue images from the same submitter. */
+export const getPlayerGroupingKey = (
+  image: { title?: string; description?: string; data?: Partial<Tag> },
+  cache?: typeof TinyCache
+): string | null => {
+  const playerId =
+    image.data?.playerId ||
+    getPlayerIdFromText(image.title!, '', cache) ||
+    getPlayerIdFromText(image.description!, '', cache)
+
+  if (playerId?.length) return playerId
+
+  const fallback = image.data?.foundPlayer || image.data?.mysteryPlayer
+  const player = getPlayerFromText(image.description!, fallback, cache)
+  return player?.length ? player : null
+}
+
+/** Stable player identity for tag payloads (prefers playerId). */
+export const getTagPlayerIdentity = (
+  tag: Partial<Pick<Tag, 'playerId' | 'foundPlayer' | 'mysteryPlayer'>>
+): string | null => {
+  if (tag.playerId?.length) return tag.playerId
+  return tag.foundPlayer || tag.mysteryPlayer || null
+}
+
 export const getFoundLocationFromText = (
   inputText: string,
   fallback?: string,
   cache?: typeof TinyCache
 ): string => {
-  if (!inputText?.length) return fallback
+  if (!inputText?.length) return fallback!
 
   const cacheKey = `${cacheKeys.locationText}${inputText}`
   const existingParsed = getCacheIfExists(cacheKey, cache)
@@ -148,7 +173,7 @@ export const getFoundLocationFromText = (
   if (!foundLocationText) {
     fallback = fallback ?? null
     putCacheIfExists(cacheKey, fallback, cache)
-    return fallback
+    return fallback!
   }
 
   const foundLocation = (

--- a/src/imgur/getQueue.ts
+++ b/src/imgur/getQueue.ts
@@ -29,7 +29,7 @@ export async function getQueue(
     albumInfo?.data?.images ?? [],
     cache
   )
-  const queuedTags = getGroupedTagsByPlayer(images, payload)
+  const queuedTags = getGroupedTagsByPlayer(images, payload, cache)
 
   return {
     data: sortTags(queuedTags, 'relevance'),

--- a/src/imgur/helpers.ts
+++ b/src/imgur/helpers.ts
@@ -11,6 +11,7 @@ import {
   getImgurMysteryDescriptionFromBikeTagData,
   getImgurMysteryImageHashFromBikeTagData,
   getImgurMysteryTitleFromBikeTagData,
+  getPlayerGroupingKey,
 } from '../common/getters'
 import { cacheKeys, createGameObject, createPlayerObject } from '../common/data'
 
@@ -782,7 +783,8 @@ export const getGroupedTagsByTagnumber = (
 
 export const getGroupedTagsByPlayer = (
   groupedImages: ImgurImage[][] = [],
-  appendToTagData = {}
+  appendToTagData = {},
+  cache?: typeof TinyCache
 ) => {
   if (!groupedImages.length) {
     return []
@@ -796,13 +798,15 @@ export const getGroupedTagsByPlayer = (
   }, 0)
 
   groupedImages[highestTagnumber].forEach((i: ImgurImage) => {
-    const player = getPlayerFromText(i.description)
+    const player = getPlayerGroupingKey(i, cache)
+    if (!player) return
     playerGroupedImages[player] = playerGroupedImages[player] ?? []
     playerGroupedImages[player].push(i)
   })
   if (groupedImages[highestTagnumber - 1]) {
     groupedImages[highestTagnumber - 1].forEach((i: ImgurImage) => {
-      const player = getPlayerFromText(i.description)
+      const player = getPlayerGroupingKey(i, cache)
+      if (!player) return
       playerGroupedImages[player] = playerGroupedImages[player] ?? []
       playerGroupedImages[player].push(i)
     })

--- a/test/src/common/getPlayerGroupingKey.test.ts
+++ b/test/src/common/getPlayerGroupingKey.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'vitest'
+import { getPlayerGroupingKey } from '../../../src/common/getters'
+import {
+  getGroupedTagsByPlayer,
+  parseTagnumberFromQueueKey,
+} from '../../../src/aws/helpers'
+import { S3ImageMeta } from '../../../src/common/types'
+
+describe('getPlayerGroupingKey', () => {
+  test('groups by playerId from metadata even when display names differ', () => {
+    const playerId = 'did:plc:abc123'
+
+    const mystery: S3ImageMeta = {
+      description: '#100 tag (hint: tree) by Alice on [1/1/24@10:00:00]',
+      title: `[${playerId}]`,
+      data: {
+        tagnumber: 100,
+        playerId,
+        mysteryPlayer: 'Alice',
+      },
+    }
+
+    const found: S3ImageMeta = {
+      description:
+        '#99 proof found at (Park) by alice.bsky.social on [1/1/24@09:00:00]',
+      title: `[${playerId}]`,
+      data: {
+        tagnumber: 99,
+        playerId,
+        foundPlayer: 'alice.bsky.social',
+      },
+    }
+
+    expect(getPlayerGroupingKey(mystery)).toBe(playerId)
+    expect(getPlayerGroupingKey(found)).toBe(playerId)
+    expect(getPlayerGroupingKey(mystery)).toBe(getPlayerGroupingKey(found))
+  })
+
+  test('falls back to metadata player name when description is empty', () => {
+    const image: S3ImageMeta = {
+      description: '',
+      data: { tagnumber: 100, mysteryPlayer: 'Bob' },
+    }
+
+    expect(getPlayerGroupingKey(image)).toBe('Bob')
+  })
+})
+
+describe('getGroupedTagsByPlayer', () => {
+  test('pairs mystery and found images for the same playerId', () => {
+    const playerId = 'did:plc:shared-player'
+    const groupedImages: S3ImageMeta[][] = []
+
+    groupedImages[99] = [
+      {
+        description:
+          '#99 proof found at (Park) by FinderName on [1/1/24@09:00:00]',
+        title: `[${playerId}]`,
+        url: 'https://example.com/found.webp',
+        data: {
+          tagnumber: 99,
+          playerId,
+          foundPlayer: 'FinderName',
+          foundTime: 1,
+          foundLocation: 'Park',
+        },
+      },
+    ]
+
+    groupedImages[100] = [
+      {
+        description:
+          '#100 tag (hint: tree) by Different Display Name on [1/1/24@10:00:00]',
+        title: `[${playerId}]`,
+        url: 'https://example.com/mystery.webp',
+        data: {
+          tagnumber: 100,
+          playerId,
+          mysteryPlayer: 'Different Display Name',
+          mysteryTime: 2,
+          hint: 'tree',
+        },
+      },
+    ]
+
+    const tags = getGroupedTagsByPlayer(groupedImages, { game: 'test' })
+
+    expect(tags).toHaveLength(1)
+    expect(tags[0].playerId).toBe(playerId)
+    expect(tags[0].mysteryImageUrl).toContain('mystery')
+    expect(tags[0].foundImageUrl).toContain('found')
+  })
+})
+
+describe('parseTagnumberFromQueueKey', () => {
+  test('extracts tagnumber from queue object keys', () => {
+    expect(
+      parseTagnumberFromQueueKey('queue/portland-tag-100--mystery--a1b2c3.webp')
+    ).toBe(100)
+    expect(
+      parseTagnumberFromQueueKey('queue/portland-tag-99--found--d4e5f6.webp')
+    ).toBe(99)
+  })
+})


### PR DESCRIPTION
Queue images for mystery and found use different tagnumbers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved queue rebuilding by reconstructing tags from image metadata, making queue results more reliable.
  * Better player grouping across image sources, including support for more accurate matching and tag pairing.

* **Bug Fixes**
  * Reduced duplicate or missed queue entries by tightening how player identity is detected.
  * Improved handling of missing or incomplete metadata when grouping tags and rebuilding queues.

* **Tests**
  * Added coverage for player grouping, queue key parsing, and tag pairing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->