### PR TITLE
fix(aws): fixes a bug regarding already queued tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biketag",
-  "version": "3.5.39",
+  "version": "3.5.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biketag",
-      "version": "3.5.39",
+      "version": "3.5.41",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.839.0",
@@ -57,7 +57,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=24.10.0"
       },
       "funding": {
         "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biketag",
-  "version": "3.5.39",
+  "version": "3.5.41",
   "description": "The Javascript client API for BikeTag Games",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -30,7 +30,7 @@
     "url": "https://github.com/KenEucker/biketag-api/issues"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=24.10.0"
   },
   "funding": {
     "type": "patreon",

--- a/src/aws/queueTag.ts
+++ b/src/aws/queueTag.ts
@@ -24,7 +24,7 @@ export async function queueTag(
   const playerIdentity = getTagPlayerIdentity(payload)
 
   const playerAlreadyQueuedError =
-    !isCompleteQueuedTag &&
+    isCompleteQueuedTag &&
     !!playerIdentity &&
     queuedTags.some((t) => getTagPlayerIdentity(t) === playerIdentity)
 
@@ -105,7 +105,7 @@ export async function queueTag(
   }
 
   return {
-    data: tagData,
+    data: tagData!,
     success,
     error,
     source: AvailableApis[AvailableApis.aws],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where players could receive the wrong conflict response when a queue tag was already in use.
  * Improved response consistency when returning queue tag data.

* **Chores**
  * Bumped the package version.
  * Updated the minimum supported Node.js version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->