### PR TITLE
fix(aws): key queued found images to current round

### DIFF
--- a/src/aws/uploadTagImage.ts
+++ b/src/aws/uploadTagImage.ts
@@ -1,4 +1,8 @@
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import {
+  S3Client,
+  CopyObjectCommand,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3'
 import { createTagObject } from '../common/data'
 import { AvailableApis, HttpStatusCode } from '../common/enums'
 import { BikeTagApiResponse } from '../common/types'
@@ -51,6 +55,49 @@ export async function uploadTagImage(
     const folder = payload.folder ?? 'queue'
     const player =
       type === 'mystery' ? payload.mysteryPlayer : payload.foundPlayer
+    const isCompleteQueuedTag =
+      folder === 'queue' &&
+      !!(payload.mysteryImageUrl || payload.mysteryImage) &&
+      !!(payload.foundImageUrl || payload.foundImage)
+    const imageTagnumber =
+      type === 'found' &&
+      isCompleteQueuedTag &&
+      typeof payload.tagnumber === 'number'
+        ? payload.tagnumber - 1
+        : payload.tagnumber
+
+    if (type === 'mystery' && !payload.mysteryTime) {
+      payload.mysteryTime = Math.floor(Date.now() / 1000)
+    } else if (type === 'found' && !payload.foundTime) {
+      payload.foundTime = Math.floor(Date.now() / 1000)
+    }
+
+    const metadataPayload = { ...payload, tagnumber: imageTagnumber } as Tag
+    const metadata = {
+      data:
+        type === 'mystery'
+          ? getMysteryMetadata(metadataPayload)
+          : getFoundMetadata(metadataPayload),
+    }
+    const replaceExistingImageMetadata = async (key: string) => {
+      try {
+        await client.send(
+          new CopyObjectCommand({
+            Bucket: bucket,
+            CopySource: `${bucket}/${key}`,
+            Key: key,
+            ACL: 'public-read',
+            MetadataDirective: 'REPLACE',
+            Metadata: metadata,
+          })
+        )
+        return true
+      } catch (err: any) {
+        success = false
+        errors.push(`Failed to update ${type} image metadata: ${err.message}`)
+        return false
+      }
+    }
 
     let contentType = payload.contentType
     const existingUrl = payload[urlField]
@@ -68,7 +115,7 @@ export async function uploadTagImage(
       const expectedKey = await getBikeTagImageKey(
         type,
         player,
-        payload.tagnumber,
+        imageTagnumber,
         payload.game,
         contentType,
         folder
@@ -79,6 +126,8 @@ export async function uploadTagImage(
         logVerbose(
           `[uploadTagImage] ${type} image already in correct location.`
         )
+        const metadataUpdated = await replaceExistingImageMetadata(expectedKey)
+        if (!metadataUpdated) return undefined
         return existingUrl
       }
 
@@ -91,6 +140,8 @@ export async function uploadTagImage(
       )
       if (moveResult.success) {
         logVerbose(`[uploadTagImage] Moved ${type} image successfully.`)
+        const metadataUpdated = await replaceExistingImageMetadata(expectedKey)
+        if (!metadataUpdated) return undefined
         return expectedUrl
       }
 
@@ -128,7 +179,7 @@ export async function uploadTagImage(
     const key = await getBikeTagImageKey(
       type,
       player,
-      payload.tagnumber,
+      imageTagnumber,
       payload.game,
       contentType,
       folder
@@ -141,12 +192,6 @@ export async function uploadTagImage(
       return undefined
     }
 
-    if (type === 'mystery' && !payload.mysteryTime) {
-      payload.mysteryTime = Math.floor(Date.now() / 1000)
-    } else if (type === 'found' && !payload.foundTime) {
-      payload.foundTime = Math.floor(Date.now() / 1000)
-    }
-
     try {
       if (typeof window === 'undefined') {
         logVerbose(`[uploadTagImage] Uploading ${type} image to S3 (Node)...`)
@@ -157,12 +202,7 @@ export async function uploadTagImage(
             Body: await normalizeUploadBody(payload[blobField]),
             ContentType: contentType,
             ACL: 'public-read',
-            Metadata: {
-              data:
-                type === 'mystery'
-                  ? getMysteryMetadata(payload as Tag)
-                  : getFoundMetadata(payload as Tag),
-            },
+            Metadata: metadata,
           })
         )
       } else if (this.fetchSignedUrl && this.plainFetcher) {
@@ -184,10 +224,7 @@ export async function uploadTagImage(
           method: 'PUT',
           headers: {
             'Content-Type': contentType,
-            'x-amz-meta-data':
-              type === 'mystery'
-                ? getMysteryMetadata(payload as Tag)
-                : getFoundMetadata(payload as Tag),
+            'x-amz-meta-data': metadata.data,
             'x-amz-acl': 'public-read',
           },
           data: await normalizeUploadBody(payload[blobField]),

--- a/test/src/aws/uploadTagImage.test.ts
+++ b/test/src/aws/uploadTagImage.test.ts
@@ -1,0 +1,109 @@
+import { CopyObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3'
+import { describe, expect, test, vi } from 'vitest'
+import { uploadTagImage } from '../../../src/aws/uploadTagImage'
+import { getBikeTagImageKey, getTagMetadata } from '../../../src/aws/helpers'
+
+describe('aws uploadTagImage', () => {
+  test('keys complete queued found images at the current round', async () => {
+    const send = vi.fn().mockResolvedValue({})
+    const client = { send }
+
+    const response = await uploadTagImage.call({}, client as any, {
+      game: 'portland',
+      folder: 'queue',
+      region: 'nyc3',
+      tagnumber: 101,
+      contentType: 'image/jpeg',
+      foundPlayer: 'Finder',
+      foundImage: new Blob(['found'], { type: 'image/jpeg' }),
+      foundLocation: 'Park',
+      mysteryPlayer: 'Finder',
+      mysteryImage: new Blob(['mystery'], { type: 'image/jpeg' }),
+      hint: 'Tree',
+    })
+
+    expect(response.success).toBe(true)
+    expect(send).toHaveBeenCalledTimes(2)
+
+    const commands = send.mock.calls.map(([command]) => command)
+    expect(
+      commands.every((command) => command instanceof PutObjectCommand)
+    ).toBe(true)
+
+    const foundInput = commands[0].input
+    const mysteryInput = commands[1].input
+
+    expect(foundInput.Key).toMatch(
+      /^queue\/portland-tag-100--found--[a-f0-9]{6}\.jpg$/
+    )
+    expect(mysteryInput.Key).toMatch(
+      /^queue\/portland-tag-101--mystery--[a-f0-9]{6}\.jpg$/
+    )
+    expect(getTagMetadata(foundInput.Metadata.data)?.tagnumber).toBe(100)
+    expect(getTagMetadata(mysteryInput.Metadata.data)?.tagnumber).toBe(101)
+  })
+
+  test('moves complete queued found images to the current round with matching metadata', async () => {
+    const send = vi.fn().mockResolvedValue({})
+    const client = { send }
+    const bucketUrl = (key: string) =>
+      `https://portland-biketag.nyc3.cdn.digitaloceanspaces.com/${key}`
+    const wrongFoundKey = await getBikeTagImageKey(
+      'found',
+      'Finder',
+      101,
+      'portland',
+      'image/jpeg',
+      'queue'
+    )
+    const expectedFoundKey = await getBikeTagImageKey(
+      'found',
+      'Finder',
+      100,
+      'portland',
+      'image/jpeg',
+      'queue'
+    )
+    const mysteryKey = await getBikeTagImageKey(
+      'mystery',
+      'Finder',
+      101,
+      'portland',
+      'image/jpeg',
+      'queue'
+    )
+
+    const response = await uploadTagImage.call({}, client as any, {
+      game: 'portland',
+      folder: 'queue',
+      region: 'nyc3',
+      tagnumber: 101,
+      foundPlayer: 'Finder',
+      foundImageUrl: bucketUrl(wrongFoundKey),
+      foundLocation: 'Park',
+      mysteryPlayer: 'Finder',
+      mysteryImageUrl: bucketUrl(mysteryKey),
+      hint: 'Tree',
+    })
+
+    expect(response.success).toBe(true)
+    expect(response.data.foundImageUrl).toBe(bucketUrl(expectedFoundKey))
+
+    const replaceMetadataInputs = send.mock.calls
+      .map(([command]) => command)
+      .filter(
+        (command) =>
+          command instanceof CopyObjectCommand &&
+          command.input.MetadataDirective === 'REPLACE'
+      )
+      .map((command) => command.input)
+    const foundMetadataUpdate = replaceMetadataInputs.find(
+      (input) => input.Key === expectedFoundKey
+    )
+
+    expect(foundMetadataUpdate).toBeDefined()
+    expect(getTagMetadata(foundMetadataUpdate!.Metadata.data)?.tagnumber).toBe(
+      100
+    )
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tag image uploads to keep image metadata aligned with the current tag number.
  * Added support for updating existing uploaded image metadata in place when needed.

* **Bug Fixes**
  * Fixed cases where uploaded images could return the wrong destination or stale metadata.
  * Ensured image URLs continue to point to the expected location after moves or replacements.

* **Tests**
  * Added coverage for uploading images from both files and existing URLs, including metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->